### PR TITLE
feat(workflows): Add pull request lint action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
         uses: morrisoncole/pr-lint-action@v1.7.1
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          title-regex: '^(feat|fix|docs|style|refactor|perf|test|chore)(\([^)]+\))?: [a-z0-9\- ]+$'
+          title-regex: '^(feat|fix|docs|style|refactor|perf|test|chore)(\([^)]+\))?: .+$'
           on-failed-regex-fail-action: true
           on-failed-regex-create-review: true
           on-failed-regex-request-changes: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,21 @@
+name: Pull Request
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  pr-lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Pull Request Title Linter
+        uses: morrisoncole/pr-lint-action@v1.7.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          title-regex: '^(feat|fix|docs|style|refactor|perf|test|chore)(\([^)]+\))?: [a-z0-9\- ]+$'
+          on-failed-regex-fail-action: true
+          on-failed-regex-create-review: true
+          on-failed-regex-request-changes: false
+          on-failed-regex-comment: "❌ The PR title should follow this format: `{type}: <description>`\n\nExamples:\n- `feat: add user login`\n- `fix(auth): handle expired token`"
+          on-succeeded-regex-dismiss-review-comment: "✅ Awesome! The PR title is correct and matches the required format."


### PR DESCRIPTION
## Description
This pull request introduces a GitHub Actions workflow to enforce pull request title conventions. The workflow ensures that PR titles follow a specific format using a linter action.

### Workflow addition:

* [`.github/workflows/pull_request.yml`](diffhunk://#diff-a0fe23534b616d51ce686d2a1bcd1a78bc75074aef1a2f6ee96c9469991e1a4cR1-R21): Added a new workflow named "Pull Request" that triggers on pull request events (`opened`, `edited`, `reopened`, `synchronize`). It includes a job (`pr-lint`) that uses the `pr-lint-action` to validate PR titles against a regex pattern. The workflow provides feedback through comments and reviews based on the title's compliance.

## Type of change

<!-- Please delete options that are not relevant -->

- [X] New Feature (non-breaking change which adds functionality)

reference(notion|figma|issue): <https://www.notion.so/xxxxxxxxxxx>

## 📷 Screenshots (if any)

Mobile:

<!-- Drag and drop screenshots or screen recording -->

Desktop:

<!-- Drag and drop screenshots or screen recording -->

## Checklist

- [X] I had tested the change locally (running `npm run preview`)
- [X] Reviewed changes in both mobile and desktop by device
- [X] My code changes follow the Code Style Guideline
- [X] My PR title follows conventional change log standards
- [X] I have included a screenshot (if it is an UI change)
