### PR TITLE
feat(onboarding): add division picker, Decide Later, and open min 2

### DIFF
--- a/src/app/2026/_actions/payment.ts
+++ b/src/app/2026/_actions/payment.ts
@@ -88,7 +88,7 @@ export async function processPayment(
   if ((count ?? 0) < minMembers) {
     return {
       success: false,
-      error: `Need at least ${minMembers} member${minMembers !== 1 ? "s" : ""} to activate`,
+      error: `Need at least ${minMembers} members to activate`,
     };
   }
 

--- a/src/app/2026/_data/teamConfig.ts
+++ b/src/app/2026/_data/teamConfig.ts
@@ -1,6 +1,6 @@
 export const MEMBER_LIMITS = {
   standard: { min: 3, max: 6 },
-  open: { min: 1, max: 6 },
+  open: { min: 2, max: 6 },
 } as const;
 
 export type TeamCategory = keyof typeof MEMBER_LIMITS;

--- a/src/app/2026/dashboard/_components/DashboardContent.tsx
+++ b/src/app/2026/dashboard/_components/DashboardContent.tsx
@@ -311,7 +311,7 @@ export default function DashboardContent({
                   onClick={() => !hasTeam && setTab("team")}
                 />
                 <ActionItem
-                  label={`Get at least ${minMembers} team member${minMembers !== 1 ? "s" : ""}`}
+                  label={`Get at least ${minMembers} team members`}
                   done={hasEnoughMembers}
                   onClick={() =>
                     hasTeam && !hasEnoughMembers && setTab("team")

--- a/src/app/2026/onboarding/_components/CreateTeamForm.tsx
+++ b/src/app/2026/onboarding/_components/CreateTeamForm.tsx
@@ -8,6 +8,7 @@ import Input from "@/app/2026/_components/ui/Input";
 import Select from "@/app/2026/_components/ui/Select";
 import { Button } from "@/app/2026/_components/ui/Button";
 import type { UserType } from "./UserTypeStep";
+import type { TeamCategory } from "@/app/2026/_data/teamConfig";
 
 const ALL_CATEGORY_OPTIONS = [
   {
@@ -35,10 +36,12 @@ function Field({ delay, children }: { delay: number; children: React.ReactNode }
 export default function CreateTeamForm({
   onComplete,
   userType,
+  division,
   solo = false,
 }: {
   onComplete: () => void;
   userType: UserType;
+  division: TeamCategory;
   solo?: boolean;
 }) {
   const [loading, setLoading] = useState(false);
@@ -145,7 +148,7 @@ export default function CreateTeamForm({
             name="category"
             options={categoryOptions}
             required
-            defaultValue={canJoinStandard ? "standard" : "open"}
+            defaultValue={canJoinStandard ? division : "open"}
           />
         </Field>
       )}

--- a/src/app/2026/onboarding/_components/CreateTeamForm.tsx
+++ b/src/app/2026/onboarding/_components/CreateTeamForm.tsx
@@ -17,7 +17,7 @@ const ALL_CATEGORY_OPTIONS = [
   },
   {
     value: "open",
-    label: "Open (Inter-uni, 1-6 members)",
+    label: "Open (Inter-uni, 2-6 members)",
   },
 ];
 
@@ -37,18 +37,16 @@ export default function CreateTeamForm({
   onComplete,
   userType,
   division,
-  solo = false,
 }: {
   onComplete: () => void;
   userType: UserType;
   division: TeamCategory;
-  solo?: boolean;
 }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [joinCode, setJoinCode] = useState<string | null>(null);
 
-  const canJoinStandard = userType === "unsw" && !solo;
+  const canJoinStandard = userType === "unsw";
   const categoryOptions = canJoinStandard
     ? ALL_CATEGORY_OPTIONS
     : ALL_CATEGORY_OPTIONS.filter((opt) => opt.value === "open");
@@ -61,7 +59,7 @@ export default function CreateTeamForm({
     const form = new FormData(e.currentTarget);
     const result = await createTeam({
       name: form.get("team_name") as string,
-      category: solo ? "open" : (form.get("category") as "standard" | "open"),
+      category: form.get("category") as "standard" | "open",
     });
 
     setLoading(false);
@@ -82,12 +80,8 @@ export default function CreateTeamForm({
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4 }}
         >
-          <h3 className="mb-2">{solo ? "You're all set!" : "Team Created!"}</h3>
-          <p className="text-gray-400">
-            {solo
-              ? "Keep this code in case you want to add teammates later"
-              : "Share this code with your teammates"}
-          </p>
+          <h3 className="mb-2">Team Created!</h3>
+          <p className="text-gray-400">Share this code with your teammates</p>
         </motion.div>
         <motion.div
           className="cursor-pointer rounded-xl border border-white/10 bg-white/5 px-8 py-6 backdrop-blur-sm transition-colors hover:border-rose-500"
@@ -124,14 +118,6 @@ export default function CreateTeamForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      {solo && (
-        <Field delay={0.3}>
-          <p className="font-main text-center text-sm text-gray-400">
-            Name your solo team. You&apos;ll compete in the Open division.
-          </p>
-        </Field>
-      )}
-
       <Field delay={0.4}>
         <Input
           label="Team Name"
@@ -141,43 +127,39 @@ export default function CreateTeamForm({
         />
       </Field>
 
-      {!solo && (
-        <Field delay={0.4}>
-          <Select
-            label="Category"
-            name="category"
-            options={categoryOptions}
-            required
-            defaultValue={canJoinStandard ? division : "open"}
-          />
-        </Field>
-      )}
+      <Field delay={0.4}>
+        <Select
+          label="Category"
+          name="category"
+          options={categoryOptions}
+          required
+          defaultValue={canJoinStandard ? division : "open"}
+        />
+      </Field>
 
-      {!solo && (
-        <Field delay={0.3}>
-          <p className="font-main text-xs text-gray-500">
-            {canJoinStandard ? (
-              <>
-                <b>Standard:</b> UNSW students only, 3-6 members.{" "}
-                <b>Open:</b> Any university or high school, 1-6 members.
-              </>
-            ) : (
-              <>
-                <b>Open:</b> Any university or high school, 1-6 members.
-                {userType === "high_school"
-                  ? " High school students can only compete in the Open division."
-                  : " Non-UNSW students can only compete in the Open division."}
-              </>
-            )}
-          </p>
-        </Field>
-      )}
+      <Field delay={0.3}>
+        <p className="font-main text-xs text-gray-500">
+          {canJoinStandard ? (
+            <>
+              <b>Standard:</b> UNSW students only, 3-6 members.{" "}
+              <b>Open:</b> Any university or high school, 2-6 members.
+            </>
+          ) : (
+            <>
+              <b>Open:</b> Any university or high school, 2-6 members.
+              {userType === "high_school"
+                ? " High school students can only compete in the Open division."
+                : " Non-UNSW students can only compete in the Open division."}
+            </>
+          )}
+        </p>
+      </Field>
 
       {error && <p className="text-sm text-red-400">{error}</p>}
 
       <div className="sticky bottom-4 mt-4 pt-4">
         <Button type="submit" size="full" disabled={loading} loading={loading}>
-          {loading ? "Creating..." : solo ? "Go Solo" : "Create Team"}
+          {loading ? "Creating..." : "Create Team"}
         </Button>
       </div>
     </form>

--- a/src/app/2026/onboarding/_components/CreateTeamForm.tsx
+++ b/src/app/2026/onboarding/_components/CreateTeamForm.tsx
@@ -35,15 +35,17 @@ function Field({ delay, children }: { delay: number; children: React.ReactNode }
 export default function CreateTeamForm({
   onComplete,
   userType,
+  solo = false,
 }: {
   onComplete: () => void;
   userType: UserType;
+  solo?: boolean;
 }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [joinCode, setJoinCode] = useState<string | null>(null);
 
-  const canJoinStandard = userType === "unsw";
+  const canJoinStandard = userType === "unsw" && !solo;
   const categoryOptions = canJoinStandard
     ? ALL_CATEGORY_OPTIONS
     : ALL_CATEGORY_OPTIONS.filter((opt) => opt.value === "open");
@@ -56,7 +58,7 @@ export default function CreateTeamForm({
     const form = new FormData(e.currentTarget);
     const result = await createTeam({
       name: form.get("team_name") as string,
-      category: form.get("category") as "standard" | "open",
+      category: solo ? "open" : (form.get("category") as "standard" | "open"),
     });
 
     setLoading(false);
@@ -77,8 +79,12 @@ export default function CreateTeamForm({
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4 }}
         >
-          <h3 className="mb-2">Team Created!</h3>
-          <p className="text-gray-400">Share this code with your teammates</p>
+          <h3 className="mb-2">{solo ? "You're all set!" : "Team Created!"}</h3>
+          <p className="text-gray-400">
+            {solo
+              ? "Keep this code in case you want to add teammates later"
+              : "Share this code with your teammates"}
+          </p>
         </motion.div>
         <motion.div
           className="cursor-pointer rounded-xl border border-white/10 bg-white/5 px-8 py-6 backdrop-blur-sm transition-colors hover:border-rose-500"
@@ -115,6 +121,14 @@ export default function CreateTeamForm({
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      {solo && (
+        <Field delay={0.3}>
+          <p className="font-main text-center text-sm text-gray-400">
+            Name your solo team. You&apos;ll compete in the Open division.
+          </p>
+        </Field>
+      )}
+
       <Field delay={0.4}>
         <Input
           label="Team Name"
@@ -124,39 +138,43 @@ export default function CreateTeamForm({
         />
       </Field>
 
-      <Field delay={0.4}>
-        <Select
-          label="Category"
-          name="category"
-          options={categoryOptions}
-          required
-          defaultValue={canJoinStandard ? "standard" : "open"}
-        />
-      </Field>
+      {!solo && (
+        <Field delay={0.4}>
+          <Select
+            label="Category"
+            name="category"
+            options={categoryOptions}
+            required
+            defaultValue={canJoinStandard ? "standard" : "open"}
+          />
+        </Field>
+      )}
 
-      <Field delay={0.3}>
-        <p className="font-main text-xs text-gray-500">
-          {canJoinStandard ? (
-            <>
-              <b>Standard:</b> UNSW students only, 3-6 members.{" "}
-              <b>Open:</b> Any university or high school, 1-6 members.
-            </>
-          ) : (
-            <>
-              <b>Open:</b> Any university or high school, 1-6 members.
-              {userType === "high_school"
-                ? " High school students can only compete in the Open division."
-                : " Non-UNSW students can only compete in the Open division."}
-            </>
-          )}
-        </p>
-      </Field>
+      {!solo && (
+        <Field delay={0.3}>
+          <p className="font-main text-xs text-gray-500">
+            {canJoinStandard ? (
+              <>
+                <b>Standard:</b> UNSW students only, 3-6 members.{" "}
+                <b>Open:</b> Any university or high school, 1-6 members.
+              </>
+            ) : (
+              <>
+                <b>Open:</b> Any university or high school, 1-6 members.
+                {userType === "high_school"
+                  ? " High school students can only compete in the Open division."
+                  : " Non-UNSW students can only compete in the Open division."}
+              </>
+            )}
+          </p>
+        </Field>
+      )}
 
       {error && <p className="text-sm text-red-400">{error}</p>}
 
       <div className="sticky bottom-4 mt-4 pt-4">
         <Button type="submit" size="full" disabled={loading} loading={loading}>
-          {loading ? "Creating..." : "Create Team"}
+          {loading ? "Creating..." : solo ? "Go Solo" : "Create Team"}
         </Button>
       </div>
     </form>

--- a/src/app/2026/onboarding/_components/DivisionStep.tsx
+++ b/src/app/2026/onboarding/_components/DivisionStep.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { motion } from "motion/react";
+import type { TeamCategory } from "@/app/2026/_data/teamConfig";
+
+const DIVISION_OPTIONS: {
+  value: TeamCategory;
+  title: string;
+  description: string;
+}[] = [
+  {
+    value: "standard",
+    title: "Standard",
+    description: "UNSW students only, 3-6 members per team",
+  },
+  {
+    value: "open",
+    title: "Open",
+    description: "Any university or high school, 1-6 members (solo allowed)",
+  },
+];
+
+export default function DivisionStep({
+  onSelect,
+  onBack,
+}: {
+  onSelect: (division: TeamCategory) => void;
+  onBack: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-6">
+      <motion.div
+        className="text-center"
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.4 }}
+      >
+        <h2 className="mb-2 text-2xl sm:text-3xl">Which division?</h2>
+        <p className="font-main text-sm text-gray-400">
+          As a UNSW student you can compete in either division
+        </p>
+      </motion.div>
+
+      <div className="flex w-full flex-col gap-3">
+        {DIVISION_OPTIONS.map((opt, i) => (
+          <motion.button
+            key={opt.value}
+            type="button"
+            onClick={() => onSelect(opt.value)}
+            className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-white/10 bg-white/5 p-5 text-white backdrop-blur-sm transition-colors hover:border-rose-500 hover:bg-white/10"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{
+              delay: 0.2 + i * 0.1,
+              duration: 0.35,
+              ease: [0.25, 0.46, 0.45, 0.94],
+            }}
+            whileHover={{ scale: 1.01 }}
+            whileTap={{ scale: 0.98 }}
+          >
+            <span className="font-display text-lg">{opt.title}</span>
+            <span className="text-sm text-gray-400">{opt.description}</span>
+          </motion.button>
+        ))}
+      </div>
+
+      <motion.button
+        type="button"
+        onClick={onBack}
+        className="font-main text-sm text-gray-400 transition-colors hover:text-white"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.5, duration: 0.3 }}
+      >
+        &larr; Back
+      </motion.button>
+    </div>
+  );
+}

--- a/src/app/2026/onboarding/_components/DivisionStep.tsx
+++ b/src/app/2026/onboarding/_components/DivisionStep.tsx
@@ -16,7 +16,7 @@ const DIVISION_OPTIONS: {
   {
     value: "open",
     title: "Open",
-    description: "Any university or high school, 1-6 members (solo allowed)",
+    description: "Any university or high school, 2-6 members",
   },
 ];
 

--- a/src/app/2026/onboarding/_components/OnboardingFlow.tsx
+++ b/src/app/2026/onboarding/_components/OnboardingFlow.tsx
@@ -152,6 +152,7 @@ export default function OnboardingFlow({
           >
             <TeamStep
               onComplete={handleTeamComplete}
+              onBack={!hasProfile ? () => setStep(1) : undefined}
               hasTeam={hasTeam}
               userType={userType ?? "unsw"}
             />

--- a/src/app/2026/onboarding/_components/OnboardingFlow.tsx
+++ b/src/app/2026/onboarding/_components/OnboardingFlow.tsx
@@ -7,10 +7,12 @@ import StepIndicator from "./StepIndicator";
 import AccountBar from "./AccountBar";
 import UserTypeStep from "./UserTypeStep";
 import type { UserType } from "./UserTypeStep";
+import DivisionStep from "./DivisionStep";
 import StudentDetailsForm from "./StudentDetailsForm";
 import TeamStep from "./TeamStep";
 import { Button } from "@/app/2026/_components/ui/Button";
 import Path from "@/app/path";
+import type { TeamCategory } from "@/app/2026/_data/teamConfig";
 
 const stepVariants = {
   enter: {
@@ -38,6 +40,7 @@ export default function OnboardingFlow({
   const initialStep = hasProfile ? 3 : 0;
   const [step, setStep] = useState(initialStep);
   const [userType, setUserType] = useState<UserType | null>(null);
+  const [division, setDivision] = useState<TeamCategory | null>(null);
 
   function handleStart() {
     setStep(1);
@@ -45,7 +48,24 @@ export default function OnboardingFlow({
 
   function handleUserTypeSelect(type: UserType) {
     setUserType(type);
+    if (type === "unsw") {
+      // UNSW students pick their division before continuing
+      setDivision(null);
+    } else {
+      // Non-UNSW are always Open
+      setDivision("open");
+      setStep(2);
+    }
+  }
+
+  function handleDivisionSelect(div: TeamCategory) {
+    setDivision(div);
     setStep(2);
+  }
+
+  function handleDivisionBack() {
+    setUserType(null);
+    setDivision(null);
   }
 
   function handleProfileComplete() {
@@ -55,6 +75,9 @@ export default function OnboardingFlow({
   function handleTeamComplete() {
     router.push(Path[2026].Dashboard);
   }
+
+  // Within step 1, UNSW users who haven't picked a division yet see DivisionStep
+  const showDivisionPicker = step === 1 && userType === "unsw" && !division;
 
   return (
     <div>
@@ -107,7 +130,7 @@ export default function OnboardingFlow({
           </motion.div>
         )}
 
-        {step === 1 && (
+        {step === 1 && !showDivisionPicker && (
           <motion.div
             key="step-1"
             variants={stepVariants}
@@ -120,6 +143,25 @@ export default function OnboardingFlow({
             }}
           >
             <UserTypeStep onSelect={handleUserTypeSelect} />
+          </motion.div>
+        )}
+
+        {showDivisionPicker && (
+          <motion.div
+            key="step-1-division"
+            variants={stepVariants}
+            initial="enter"
+            animate="center"
+            exit="exit"
+            transition={{
+              duration: 0.35,
+              ease: [0.25, 0.46, 0.45, 0.94],
+            }}
+          >
+            <DivisionStep
+              onSelect={handleDivisionSelect}
+              onBack={handleDivisionBack}
+            />
           </motion.div>
         )}
 
@@ -152,9 +194,13 @@ export default function OnboardingFlow({
           >
             <TeamStep
               onComplete={handleTeamComplete}
-              onBack={!hasProfile ? () => setStep(1) : undefined}
+              onBack={!hasProfile ? () => {
+                setStep(1);
+                setDivision(null);
+              } : undefined}
               hasTeam={hasTeam}
               userType={userType ?? "unsw"}
+              division={division ?? "open"}
             />
           </motion.div>
         )}

--- a/src/app/2026/onboarding/_components/OnboardingFlow.tsx
+++ b/src/app/2026/onboarding/_components/OnboardingFlow.tsx
@@ -194,10 +194,6 @@ export default function OnboardingFlow({
           >
             <TeamStep
               onComplete={handleTeamComplete}
-              onBack={!hasProfile ? () => {
-                setStep(1);
-                setDivision(null);
-              } : undefined}
               hasTeam={hasTeam}
               userType={userType ?? "unsw"}
               division={division ?? "open"}

--- a/src/app/2026/onboarding/_components/TeamStep.tsx
+++ b/src/app/2026/onboarding/_components/TeamStep.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import CreateTeamForm from "./CreateTeamForm";
 import JoinTeamForm from "./JoinTeamForm";
+import { markOnboarded } from "@/app/2026/_actions/profile";
 import type { UserType } from "./UserTypeStep";
 
 export default function TeamStep({
@@ -15,13 +16,27 @@ export default function TeamStep({
   hasTeam: boolean;
   userType: UserType;
 }) {
-  const [mode, setMode] = useState<"choose" | "create" | "join">(
+  const [mode, setMode] = useState<"choose" | "create" | "join" | "solo">(
     hasTeam ? "create" : "choose",
   );
+  const [delaying, setDelaying] = useState(false);
+  const [delayError, setDelayError] = useState("");
 
   if (hasTeam) {
     onComplete();
     return null;
+  }
+
+  async function handleDecideLater() {
+    setDelaying(true);
+    setDelayError("");
+    const result = await markOnboarded();
+    if (result.success) {
+      onComplete();
+    } else {
+      setDelaying(false);
+      setDelayError(result.error || "Failed to skip team selection");
+    }
   }
 
   return (
@@ -36,7 +51,7 @@ export default function TeamStep({
           className="flex flex-col gap-4"
         >
           <p className="font-main text-center text-gray-400">
-            Create a new team or join an existing one with a code
+            Create a team, join one with a code, or go it alone
           </p>
           <motion.button
             type="button"
@@ -62,6 +77,36 @@ export default function TeamStep({
               Enter a join code from your captain
             </span>
           </motion.button>
+          <motion.button
+            type="button"
+            onClick={() => setMode("solo")}
+            className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-white/10 bg-white/5 p-5 text-white backdrop-blur-sm transition-colors hover:border-rose-500 hover:bg-white/10"
+            whileHover={{ scale: 1.01 }}
+            whileTap={{ scale: 0.98 }}
+          >
+            <span className="font-display text-lg">Go Solo</span>
+            <span className="text-sm text-gray-400">
+              Compete on your own in the Open division
+            </span>
+          </motion.button>
+          <motion.button
+            type="button"
+            onClick={handleDecideLater}
+            disabled={delaying}
+            className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-white/10 bg-white/5 p-5 text-white backdrop-blur-sm transition-colors hover:border-rose-500 hover:bg-white/10 disabled:pointer-events-none disabled:opacity-50"
+            whileHover={{ scale: delaying ? 1 : 1.01 }}
+            whileTap={{ scale: delaying ? 1 : 0.98 }}
+          >
+            <span className="font-display text-lg">
+              {delaying ? "Saving..." : "Decide Later"}
+            </span>
+            <span className="text-sm text-gray-400">
+              Skip for now and set up your team from the dashboard
+            </span>
+          </motion.button>
+          {delayError && (
+            <p className="text-center text-sm text-red-400">{delayError}</p>
+          )}
         </motion.div>
       )}
 
@@ -80,10 +125,14 @@ export default function TeamStep({
           >
             &larr; Back
           </button>
-          {mode === "create" ? (
+          {mode === "create" && (
             <CreateTeamForm onComplete={onComplete} userType={userType} />
-          ) : (
+          )}
+          {mode === "join" && (
             <JoinTeamForm onComplete={onComplete} userType={userType} />
+          )}
+          {mode === "solo" && (
+            <CreateTeamForm onComplete={onComplete} userType={userType} solo />
           )}
         </motion.div>
       )}

--- a/src/app/2026/onboarding/_components/TeamStep.tsx
+++ b/src/app/2026/onboarding/_components/TeamStep.tsx
@@ -6,19 +6,22 @@ import CreateTeamForm from "./CreateTeamForm";
 import JoinTeamForm from "./JoinTeamForm";
 import { markOnboarded } from "@/app/2026/_actions/profile";
 import type { UserType } from "./UserTypeStep";
+import type { TeamCategory } from "@/app/2026/_data/teamConfig";
 
 export default function TeamStep({
   onComplete,
   onBack,
   hasTeam,
   userType,
+  division,
 }: {
   onComplete: () => void;
   onBack?: () => void;
   hasTeam: boolean;
   userType: UserType;
+  division: TeamCategory;
 }) {
-  const isStandard = userType === "unsw";
+  const isStandard = division === "standard";
   const [mode, setMode] = useState<"choose" | "create" | "join" | "solo">(
     hasTeam ? "create" : "choose",
   );
@@ -54,7 +57,7 @@ export default function TeamStep({
           className="flex flex-col gap-4"
         >
           <p className="font-main text-center text-gray-400">
-            Create a team, join one with a code, or go it alone
+            Create a team, join one with a code{!isStandard && ", or go it alone"}
           </p>
           <motion.button
             type="button"
@@ -80,42 +83,20 @@ export default function TeamStep({
               Enter a join code from your captain
             </span>
           </motion.button>
-          <motion.button
-            type="button"
-            onClick={() => !isStandard && setMode("solo")}
-            disabled={isStandard}
-            className={
-              isStandard
-                ? "font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-white/10 bg-white/5 p-5 text-white/40 backdrop-blur-sm opacity-50 cursor-not-allowed"
-                : "font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-white/10 bg-white/5 p-5 text-white backdrop-blur-sm transition-colors hover:border-rose-500 hover:bg-white/10"
-            }
-            whileHover={{ scale: isStandard ? 1 : 1.01 }}
-            whileTap={{ scale: isStandard ? 1 : 0.98 }}
-          >
-            <span className="font-display text-lg">Go Solo</span>
-            <span className="text-sm text-gray-400">
-              Compete on your own in the Open division
-            </span>
-            {isStandard && (
-              <span className="mt-1 text-xs text-rose-400/80">
-                Solo is Open division only.{" "}
-                {onBack ? (
-                  <button
-                    type="button"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onBack();
-                    }}
-                    className="underline transition-colors hover:text-rose-300"
-                  >
-                    Go back to switch to Open
-                  </button>
-                ) : (
-                  "Go back to switch to Open."
-                )}
+          {!isStandard && (
+            <motion.button
+              type="button"
+              onClick={() => setMode("solo")}
+              className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-white/10 bg-white/5 p-5 text-white backdrop-blur-sm transition-colors hover:border-rose-500 hover:bg-white/10"
+              whileHover={{ scale: 1.01 }}
+              whileTap={{ scale: 0.98 }}
+            >
+              <span className="font-display text-lg">Go Solo</span>
+              <span className="text-sm text-gray-400">
+                Compete on your own in the Open division
               </span>
-            )}
-          </motion.button>
+            </motion.button>
+          )}
           <motion.button
             type="button"
             onClick={handleDecideLater}
@@ -153,13 +134,13 @@ export default function TeamStep({
             &larr; Back
           </button>
           {mode === "create" && (
-            <CreateTeamForm onComplete={onComplete} userType={userType} />
+            <CreateTeamForm onComplete={onComplete} userType={userType} division={division} />
           )}
           {mode === "join" && (
             <JoinTeamForm onComplete={onComplete} userType={userType} />
           )}
           {mode === "solo" && (
-            <CreateTeamForm onComplete={onComplete} userType={userType} solo />
+            <CreateTeamForm onComplete={onComplete} userType={userType} division={division} solo />
           )}
         </motion.div>
       )}

--- a/src/app/2026/onboarding/_components/TeamStep.tsx
+++ b/src/app/2026/onboarding/_components/TeamStep.tsx
@@ -9,13 +9,16 @@ import type { UserType } from "./UserTypeStep";
 
 export default function TeamStep({
   onComplete,
+  onBack,
   hasTeam,
   userType,
 }: {
   onComplete: () => void;
+  onBack?: () => void;
   hasTeam: boolean;
   userType: UserType;
 }) {
+  const isStandard = userType === "unsw";
   const [mode, setMode] = useState<"choose" | "create" | "join" | "solo">(
     hasTeam ? "create" : "choose",
   );
@@ -79,15 +82,39 @@ export default function TeamStep({
           </motion.button>
           <motion.button
             type="button"
-            onClick={() => setMode("solo")}
-            className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-white/10 bg-white/5 p-5 text-white backdrop-blur-sm transition-colors hover:border-rose-500 hover:bg-white/10"
-            whileHover={{ scale: 1.01 }}
-            whileTap={{ scale: 0.98 }}
+            onClick={() => !isStandard && setMode("solo")}
+            disabled={isStandard}
+            className={
+              isStandard
+                ? "font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-white/10 bg-white/5 p-5 text-white/40 backdrop-blur-sm opacity-50 cursor-not-allowed"
+                : "font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-white/10 bg-white/5 p-5 text-white backdrop-blur-sm transition-colors hover:border-rose-500 hover:bg-white/10"
+            }
+            whileHover={{ scale: isStandard ? 1 : 1.01 }}
+            whileTap={{ scale: isStandard ? 1 : 0.98 }}
           >
             <span className="font-display text-lg">Go Solo</span>
             <span className="text-sm text-gray-400">
               Compete on your own in the Open division
             </span>
+            {isStandard && (
+              <span className="mt-1 text-xs text-rose-400/80">
+                Solo is Open division only.{" "}
+                {onBack ? (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onBack();
+                    }}
+                    className="underline transition-colors hover:text-rose-300"
+                  >
+                    Go back to switch to Open
+                  </button>
+                ) : (
+                  "Go back to switch to Open."
+                )}
+              </span>
+            )}
           </motion.button>
           <motion.button
             type="button"

--- a/src/app/2026/onboarding/_components/TeamStep.tsx
+++ b/src/app/2026/onboarding/_components/TeamStep.tsx
@@ -10,19 +10,16 @@ import type { TeamCategory } from "@/app/2026/_data/teamConfig";
 
 export default function TeamStep({
   onComplete,
-  onBack,
   hasTeam,
   userType,
   division,
 }: {
   onComplete: () => void;
-  onBack?: () => void;
   hasTeam: boolean;
   userType: UserType;
   division: TeamCategory;
 }) {
-  const isStandard = division === "standard";
-  const [mode, setMode] = useState<"choose" | "create" | "join" | "solo">(
+  const [mode, setMode] = useState<"choose" | "create" | "join">(
     hasTeam ? "create" : "choose",
   );
   const [delaying, setDelaying] = useState(false);
@@ -57,7 +54,7 @@ export default function TeamStep({
           className="flex flex-col gap-4"
         >
           <p className="font-main text-center text-gray-400">
-            Create a team, join one with a code{!isStandard && ", or go it alone"}
+            Create a new team or join an existing one with a code
           </p>
           <motion.button
             type="button"
@@ -83,20 +80,6 @@ export default function TeamStep({
               Enter a join code from your captain
             </span>
           </motion.button>
-          {!isStandard && (
-            <motion.button
-              type="button"
-              onClick={() => setMode("solo")}
-              className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-white/10 bg-white/5 p-5 text-white backdrop-blur-sm transition-colors hover:border-rose-500 hover:bg-white/10"
-              whileHover={{ scale: 1.01 }}
-              whileTap={{ scale: 0.98 }}
-            >
-              <span className="font-display text-lg">Go Solo</span>
-              <span className="text-sm text-gray-400">
-                Compete on your own in the Open division
-              </span>
-            </motion.button>
-          )}
           <motion.button
             type="button"
             onClick={handleDecideLater}
@@ -138,9 +121,6 @@ export default function TeamStep({
           )}
           {mode === "join" && (
             <JoinTeamForm onComplete={onComplete} userType={userType} />
-          )}
-          {mode === "solo" && (
-            <CreateTeamForm onComplete={onComplete} userType={userType} division={division} solo />
           )}
         </motion.div>
       )}

--- a/src/app/2026/ui/page.tsx
+++ b/src/app/2026/ui/page.tsx
@@ -609,7 +609,7 @@ function MockYesNoToggle({
 function OnboardingSection() {
   const [step, setStep] = useState(0);
   const [userType, setUserType] = useState<"unsw" | "other_uni" | "high_school" | null>(null);
-  const [teamMode, setTeamMode] = useState<"choose" | "create" | "join">(
+  const [teamMode, setTeamMode] = useState<"choose" | "create" | "join" | "solo">(
     "choose",
   );
   const [joinCode, setJoinCode] = useState("");
@@ -1007,7 +1007,7 @@ function OnboardingSection() {
               {teamMode === "choose" && (
                 <div className="flex flex-col gap-4">
                   <p className="font-main text-center text-muted-foreground">
-                    Create a new team or join an existing one with a code
+                    Create a team, join one with a code, or go it alone
                   </p>
                   <motion.button
                     type="button"
@@ -1031,6 +1031,51 @@ function OnboardingSection() {
                     <span className="font-display text-lg">Join a Team</span>
                     <span className="text-sm text-muted-foreground">
                       Enter a join code from your captain
+                    </span>
+                  </motion.button>
+                  <motion.button
+                    type="button"
+                    onClick={() => !canJoinStandard && setTeamMode("solo")}
+                    disabled={canJoinStandard}
+                    className={
+                      canJoinStandard
+                        ? "font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-border bg-secondary p-5 text-foreground/40 backdrop-blur-sm opacity-50 cursor-not-allowed"
+                        : "font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-border bg-secondary p-5 text-foreground transition-colors hover:border-primary hover:bg-secondary/80"
+                    }
+                    whileHover={{ scale: canJoinStandard ? 1 : 1.01 }}
+                    whileTap={{ scale: canJoinStandard ? 1 : 0.98 }}
+                  >
+                    <span className="font-display text-lg">Go Solo</span>
+                    <span className="text-sm text-muted-foreground">
+                      Compete on your own in the Open division
+                    </span>
+                    {canJoinStandard && (
+                      <span className="mt-1 text-xs text-destructive/80">
+                        Solo is Open division only.{" "}
+                        <button
+                          type="button"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setStep(1);
+                            setTeamMode("choose");
+                          }}
+                          className="underline hover:text-destructive"
+                        >
+                          Go back to switch to Open
+                        </button>
+                      </span>
+                    )}
+                  </motion.button>
+                  <motion.button
+                    type="button"
+                    onClick={() => alert("Would mark onboarded and navigate to dashboard")}
+                    className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-border bg-secondary p-5 text-foreground transition-colors hover:border-primary hover:bg-secondary/80"
+                    whileHover={{ scale: 1.01 }}
+                    whileTap={{ scale: 0.98 }}
+                  >
+                    <span className="font-display text-lg">Decide Later</span>
+                    <span className="text-sm text-muted-foreground">
+                      Skip for now and set up your team from the dashboard
                     </span>
                   </motion.button>
                 </div>
@@ -1092,6 +1137,69 @@ function OnboardingSection() {
                     <h3 className="mb-2">Team Created!</h3>
                     <p className="text-muted-foreground">
                       Share this code with your teammates
+                    </p>
+                  </div>
+                  <div
+                    className="cursor-pointer rounded-xl border border-border bg-secondary px-8 py-6 transition-colors hover:border-primary"
+                    onClick={() => navigator.clipboard.writeText(createdCode)}
+                    title="Click to copy"
+                  >
+                    <span className="font-display text-4xl tracking-[0.3em]">
+                      {createdCode}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">Tap the code to copy</p>
+                  <Button
+                    size="full"
+                    onClick={() =>
+                      alert("Would navigate to dashboard")
+                    }
+                  >
+                    Go to Dashboard
+                  </Button>
+                </div>
+              )}
+
+              {teamMode === "solo" && !createdCode && (
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => setTeamMode("choose")}
+                    className="font-main mb-4 text-sm text-muted-foreground hover:text-foreground"
+                  >
+                    &larr; Back
+                  </button>
+                  <form
+                    onSubmit={(e) => {
+                      e.preventDefault();
+                      setCreatedCode("XK9M4R");
+                    }}
+                    className="flex flex-col gap-4"
+                  >
+                    <p className="font-main text-center text-sm text-muted-foreground">
+                      Name your solo team. You&apos;ll compete in the Open division.
+                    </p>
+                    <Input
+                      label="Team Name"
+                      name="team_name"
+                      required
+                      placeholder="e.g. The Destroyers"
+                    />
+                    <div className="sticky bottom-4 mt-4 pt-4">
+                      <Button type="submit" size="full">
+                        Go Solo
+                      </Button>
+                    </div>
+                  </form>
+                </div>
+              )}
+
+              {teamMode === "solo" && createdCode && (
+                <div className="flex flex-col items-center gap-6 text-center">
+                  <div>
+                    <h3 className="mb-2">You&apos;re all set!</h3>
+                    <p className="text-muted-foreground">
+                      Keep this code in case you want to add teammates later
                     </p>
                   </div>
                   <div

--- a/src/app/2026/ui/page.tsx
+++ b/src/app/2026/ui/page.tsx
@@ -609,6 +609,7 @@ function MockYesNoToggle({
 function OnboardingSection() {
   const [step, setStep] = useState(0);
   const [userType, setUserType] = useState<"unsw" | "other_uni" | "high_school" | null>(null);
+  const [division, setDivision] = useState<"standard" | "open" | null>(null);
   const [teamMode, setTeamMode] = useState<"choose" | "create" | "join" | "solo">(
     "choose",
   );
@@ -630,6 +631,8 @@ function OnboardingSection() {
   const isOtherUni = userType === "other_uni";
   const isHighSchool = userType === "high_school";
   const canJoinStandard = userType === "unsw";
+  const isStandard = division === "standard";
+  const showDivisionPicker = step === 1 && userType === "unsw" && !division;
 
   function handleProfileSubmit(e: FormEvent) {
     e.preventDefault();
@@ -644,6 +647,7 @@ function OnboardingSection() {
   function resetOnboarding() {
     setStep(0);
     setUserType(null);
+    setDivision(null);
     setTeamMode("choose");
     setCreatedCode(null);
     setShowJoinPreview(false);
@@ -709,7 +713,7 @@ function OnboardingSection() {
             </motion.div>
           )}
 
-          {step === 1 && (
+          {step === 1 && !showDivisionPicker && (
             <motion.div
               key="step-1"
               initial={{ opacity: 0, y: 30 }}
@@ -734,7 +738,15 @@ function OnboardingSection() {
                     <motion.button
                       key={opt.value}
                       type="button"
-                      onClick={() => { setUserType(opt.value); setStep(2); }}
+                      onClick={() => {
+                        setUserType(opt.value);
+                        if (opt.value === "unsw") {
+                          setDivision(null);
+                        } else {
+                          setDivision("open");
+                          setStep(2);
+                        }
+                      }}
                       className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-border bg-secondary p-5 text-foreground transition-colors hover:border-primary hover:bg-secondary/80"
                       whileHover={{ scale: 1.01 }}
                       whileTap={{ scale: 0.98 }}
@@ -744,6 +756,51 @@ function OnboardingSection() {
                     </motion.button>
                   ))}
                 </div>
+              </div>
+            </motion.div>
+          )}
+
+          {showDivisionPicker && (
+            <motion.div
+              key="step-1-division"
+              initial={{ opacity: 0, y: 30 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -20 }}
+              transition={{ duration: 0.35, ease: [0.25, 0.46, 0.45, 0.94] }}
+            >
+              {/* Mock DivisionStep — Standard or Open? */}
+              <div className="flex flex-col items-center gap-6">
+                <div className="text-center">
+                  <h2 className="mb-2 text-2xl sm:text-3xl">Which division?</h2>
+                  <p className="font-main text-sm text-muted-foreground">
+                    As a UNSW student you can compete in either division
+                  </p>
+                </div>
+                <div className="flex w-full flex-col gap-3">
+                  {([
+                    { value: "standard" as const, title: "Standard", desc: "UNSW students only, 3-6 members per team" },
+                    { value: "open" as const, title: "Open", desc: "Any university or high school, 1-6 members (solo allowed)" },
+                  ]).map((opt) => (
+                    <motion.button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => { setDivision(opt.value); setStep(2); }}
+                      className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-border bg-secondary p-5 text-foreground transition-colors hover:border-primary hover:bg-secondary/80"
+                      whileHover={{ scale: 1.01 }}
+                      whileTap={{ scale: 0.98 }}
+                    >
+                      <span className="font-display text-lg">{opt.title}</span>
+                      <span className="text-sm text-muted-foreground">{opt.desc}</span>
+                    </motion.button>
+                  ))}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => { setUserType(null); setDivision(null); }}
+                  className="font-main text-sm text-muted-foreground hover:text-foreground"
+                >
+                  &larr; Back
+                </button>
               </div>
             </motion.div>
           )}
@@ -1007,7 +1064,7 @@ function OnboardingSection() {
               {teamMode === "choose" && (
                 <div className="flex flex-col gap-4">
                   <p className="font-main text-center text-muted-foreground">
-                    Create a team, join one with a code, or go it alone
+                    Create a team, join one with a code{!isStandard && ", or go it alone"}
                   </p>
                   <motion.button
                     type="button"
@@ -1033,39 +1090,20 @@ function OnboardingSection() {
                       Enter a join code from your captain
                     </span>
                   </motion.button>
-                  <motion.button
-                    type="button"
-                    onClick={() => !canJoinStandard && setTeamMode("solo")}
-                    disabled={canJoinStandard}
-                    className={
-                      canJoinStandard
-                        ? "font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-border bg-secondary p-5 text-foreground/40 backdrop-blur-sm opacity-50 cursor-not-allowed"
-                        : "font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-border bg-secondary p-5 text-foreground transition-colors hover:border-primary hover:bg-secondary/80"
-                    }
-                    whileHover={{ scale: canJoinStandard ? 1 : 1.01 }}
-                    whileTap={{ scale: canJoinStandard ? 1 : 0.98 }}
-                  >
-                    <span className="font-display text-lg">Go Solo</span>
-                    <span className="text-sm text-muted-foreground">
-                      Compete on your own in the Open division
-                    </span>
-                    {canJoinStandard && (
-                      <span className="mt-1 text-xs text-destructive/80">
-                        Solo is Open division only.{" "}
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            setStep(1);
-                            setTeamMode("choose");
-                          }}
-                          className="underline hover:text-destructive"
-                        >
-                          Go back to switch to Open
-                        </button>
+                  {!isStandard && (
+                    <motion.button
+                      type="button"
+                      onClick={() => setTeamMode("solo")}
+                      className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-border bg-secondary p-5 text-foreground transition-colors hover:border-primary hover:bg-secondary/80"
+                      whileHover={{ scale: 1.01 }}
+                      whileTap={{ scale: 0.98 }}
+                    >
+                      <span className="font-display text-lg">Go Solo</span>
+                      <span className="text-sm text-muted-foreground">
+                        Compete on your own in the Open division
                       </span>
-                    )}
-                  </motion.button>
+                    </motion.button>
+                  )}
                   <motion.button
                     type="button"
                     onClick={() => alert("Would mark onboarded and navigate to dashboard")}
@@ -1105,7 +1143,7 @@ function OnboardingSection() {
                       name="category"
                       options={canJoinStandard ? CATEGORY_OPTIONS : CATEGORY_OPTIONS.filter((o) => o.value === "open")}
                       required
-                      defaultValue={canJoinStandard ? "standard" : "open"}
+                      defaultValue={canJoinStandard ? (division ?? "standard") : "open"}
                     />
                     <p className="font-main text-xs text-muted-foreground">
                       {canJoinStandard ? (

--- a/src/app/2026/ui/page.tsx
+++ b/src/app/2026/ui/page.tsx
@@ -148,7 +148,7 @@ const mockBrowseTeams: TeamBrowseItem[] = [
   { name: "RoboWarriors", category: "standard", member_count: 3 },
   { name: "Bot Busters", category: "open", member_count: 2 },
   { name: "The Pushers", category: "standard", member_count: 6 },
-  { name: "Solo Bot", category: "open", member_count: 1 },
+  { name: "Circuit Breakers", category: "open", member_count: 2 },
 ];
 
 const mockAdminTeams: AdminTeamRow[] = [
@@ -469,7 +469,7 @@ const HEARD_FROM_OPTIONS = [
 
 const CATEGORY_OPTIONS = [
   { value: "standard", label: "Standard (UNSW only, 3–6 members)" },
-  { value: "open", label: "Open (Inter-uni, 1–6 members)" },
+  { value: "open", label: "Open (Inter-uni, 2–6 members)" },
 ];
 
 function OnboardingField({ delay, children }: { delay: number; children: React.ReactNode }) {
@@ -610,7 +610,7 @@ function OnboardingSection() {
   const [step, setStep] = useState(0);
   const [userType, setUserType] = useState<"unsw" | "other_uni" | "high_school" | null>(null);
   const [division, setDivision] = useState<"standard" | "open" | null>(null);
-  const [teamMode, setTeamMode] = useState<"choose" | "create" | "join" | "solo">(
+  const [teamMode, setTeamMode] = useState<"choose" | "create" | "join">(
     "choose",
   );
   const [joinCode, setJoinCode] = useState("");
@@ -631,7 +631,6 @@ function OnboardingSection() {
   const isOtherUni = userType === "other_uni";
   const isHighSchool = userType === "high_school";
   const canJoinStandard = userType === "unsw";
-  const isStandard = division === "standard";
   const showDivisionPicker = step === 1 && userType === "unsw" && !division;
 
   function handleProfileSubmit(e: FormEvent) {
@@ -779,7 +778,7 @@ function OnboardingSection() {
                 <div className="flex w-full flex-col gap-3">
                   {([
                     { value: "standard" as const, title: "Standard", desc: "UNSW students only, 3-6 members per team" },
-                    { value: "open" as const, title: "Open", desc: "Any university or high school, 1-6 members (solo allowed)" },
+                    { value: "open" as const, title: "Open", desc: "Any university or high school, 2-6 members" },
                   ]).map((opt) => (
                     <motion.button
                       key={opt.value}
@@ -1064,7 +1063,7 @@ function OnboardingSection() {
               {teamMode === "choose" && (
                 <div className="flex flex-col gap-4">
                   <p className="font-main text-center text-muted-foreground">
-                    Create a team, join one with a code{!isStandard && ", or go it alone"}
+                    Create a new team or join an existing one with a code
                   </p>
                   <motion.button
                     type="button"
@@ -1090,20 +1089,6 @@ function OnboardingSection() {
                       Enter a join code from your captain
                     </span>
                   </motion.button>
-                  {!isStandard && (
-                    <motion.button
-                      type="button"
-                      onClick={() => setTeamMode("solo")}
-                      className="font-main flex min-h-[80px] flex-col items-center justify-center rounded-xl border border-border bg-secondary p-5 text-foreground transition-colors hover:border-primary hover:bg-secondary/80"
-                      whileHover={{ scale: 1.01 }}
-                      whileTap={{ scale: 0.98 }}
-                    >
-                      <span className="font-display text-lg">Go Solo</span>
-                      <span className="text-sm text-muted-foreground">
-                        Compete on your own in the Open division
-                      </span>
-                    </motion.button>
-                  )}
                   <motion.button
                     type="button"
                     onClick={() => alert("Would mark onboarded and navigate to dashboard")}
@@ -1149,11 +1134,11 @@ function OnboardingSection() {
                       {canJoinStandard ? (
                         <>
                           <b>Standard:</b> UNSW students only, 3–6 members.{" "}
-                          <b>Open:</b> Any university or high school, 1–6 members.
+                          <b>Open:</b> Any university or high school, 2–6 members.
                         </>
                       ) : (
                         <>
-                          <b>Open:</b> Any university or high school, 1–6 members.
+                          <b>Open:</b> Any university or high school, 2–6 members.
                           {isHighSchool
                             ? " High school students can only compete in the Open division."
                             : " Non-UNSW students can only compete in the Open division."}
@@ -1175,69 +1160,6 @@ function OnboardingSection() {
                     <h3 className="mb-2">Team Created!</h3>
                     <p className="text-muted-foreground">
                       Share this code with your teammates
-                    </p>
-                  </div>
-                  <div
-                    className="cursor-pointer rounded-xl border border-border bg-secondary px-8 py-6 transition-colors hover:border-primary"
-                    onClick={() => navigator.clipboard.writeText(createdCode)}
-                    title="Click to copy"
-                  >
-                    <span className="font-display text-4xl tracking-[0.3em]">
-                      {createdCode}
-                    </span>
-                  </div>
-                  <p className="text-xs text-muted-foreground">Tap the code to copy</p>
-                  <Button
-                    size="full"
-                    onClick={() =>
-                      alert("Would navigate to dashboard")
-                    }
-                  >
-                    Go to Dashboard
-                  </Button>
-                </div>
-              )}
-
-              {teamMode === "solo" && !createdCode && (
-                <div>
-                  <button
-                    type="button"
-                    onClick={() => setTeamMode("choose")}
-                    className="font-main mb-4 text-sm text-muted-foreground hover:text-foreground"
-                  >
-                    &larr; Back
-                  </button>
-                  <form
-                    onSubmit={(e) => {
-                      e.preventDefault();
-                      setCreatedCode("XK9M4R");
-                    }}
-                    className="flex flex-col gap-4"
-                  >
-                    <p className="font-main text-center text-sm text-muted-foreground">
-                      Name your solo team. You&apos;ll compete in the Open division.
-                    </p>
-                    <Input
-                      label="Team Name"
-                      name="team_name"
-                      required
-                      placeholder="e.g. The Destroyers"
-                    />
-                    <div className="sticky bottom-4 mt-4 pt-4">
-                      <Button type="submit" size="full">
-                        Go Solo
-                      </Button>
-                    </div>
-                  </form>
-                </div>
-              )}
-
-              {teamMode === "solo" && createdCode && (
-                <div className="flex flex-col items-center gap-6 text-center">
-                  <div>
-                    <h3 className="mb-2">You&apos;re all set!</h3>
-                    <p className="text-muted-foreground">
-                      Keep this code in case you want to add teammates later
                     </p>
                   </div>
                   <div


### PR DESCRIPTION
## Summary
- **Division picker for UNSW students**: After selecting "UNSW Student", users now choose between Standard (3-6 members) or Open (2-6 members) division. Non-UNSW users are automatically placed in Open.
- **Decide Later button**: Users can skip team setup during onboarding and create/join a team later from the dashboard.
- **Open division minimum raised to 2**: Solo teams are no longer allowed — both divisions now require a minimum number of members before activation.
- All changes synced to the `/ui` showcase route.

## Test plan
- [ ] Go through onboarding as UNSW student → verify division picker (Standard/Open) appears after user type selection
- [ ] Select Open as UNSW student → verify Go Solo is no longer shown, Create/Join/Decide Later are available
- [ ] Select Standard as UNSW student → verify Create/Join/Decide Later are available
- [ ] Go through onboarding as Other University or High School → verify no division picker, goes straight to details
- [ ] Click Decide Later → verify it marks onboarded and redirects to dashboard with "No Team Yet" state
- [ ] Create an Open team → verify dashboard shows "Get at least 2 team members" task
- [ ] Create a Standard team → verify dashboard shows "Get at least 3 team members" task
- [ ] Verify `/2026/ui` showcase reflects all changes (division picker, no solo, updated member counts)

https://claude.ai/code/session_01XNXRERexNVtGRXhH3oMFdu