### PR TITLE
feat: add CSV export endpoints for participants and teams

### DIFF
--- a/src/app/2026/admin/_components/AdminShell.tsx
+++ b/src/app/2026/admin/_components/AdminShell.tsx
@@ -53,14 +53,30 @@ export default function AdminShell({
               ))}
             </nav>
           </div>
-          <Button
-            variant="ghost"
-            size="default"
-            onClick={handleLogout}
-            disabled={isPending}
-          >
-            Logout
-          </Button>
+          <div className="flex items-center gap-2">
+            <a
+              href="/2026/admin/api/export/participants"
+              download
+              className="font-main rounded-md border border-white/20 px-3 py-1.5 text-sm text-gray-300 transition-colors hover:border-white/40 hover:text-white"
+            >
+              Export Participants
+            </a>
+            <a
+              href="/2026/admin/api/export/teams"
+              download
+              className="font-main rounded-md border border-white/20 px-3 py-1.5 text-sm text-gray-300 transition-colors hover:border-white/40 hover:text-white"
+            >
+              Export Teams
+            </a>
+            <Button
+              variant="ghost"
+              size="default"
+              onClick={handleLogout}
+              disabled={isPending}
+            >
+              Logout
+            </Button>
+          </div>
         </div>
       </header>
       <main className="mx-auto max-w-7xl px-4 py-6">{children}</main>

--- a/src/app/2026/admin/api/export/participants/route.ts
+++ b/src/app/2026/admin/api/export/participants/route.ts
@@ -1,0 +1,118 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { getSupabaseSecretClient } from "@/app/_utils/supabase";
+
+function escapeCell(value: unknown): string {
+  const str = value === null || value === undefined ? "" : String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function toCSV(headers: string[], rows: unknown[][]): string {
+  return [headers, ...rows]
+    .map((row) => row.map(escapeCell).join(","))
+    .join("\n");
+}
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const session = cookieStore.get("admin_session");
+  if (session?.value !== "authenticated") {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const supabase = getSupabaseSecretClient();
+
+  const { data: profiles } = await supabase
+    .from("profiles")
+    .select("*, team_members(team_id, role, team:teams(name, paid))")
+    .order("created_at", { ascending: false });
+
+  if (!profiles) {
+    return new NextResponse("Failed to fetch data", { status: 500 });
+  }
+
+  const headers = [
+    "id",
+    "full_name",
+    "email",
+    "phone",
+    "user_type",
+    "zid",
+    "uni_id",
+    "university",
+    "high_school",
+    "year_of_study",
+    "degree_stage",
+    "undergrad_postgrad",
+    "domestic_international",
+    "degree",
+    "majors",
+    "faculty",
+    "gender",
+    "gender_other",
+    "is_ramsoc_member",
+    "is_arc_member",
+    "heard_from",
+    "heard_from_other",
+    "onboarded",
+    "team_name",
+    "team_id",
+    "team_role",
+    "team_paid",
+    "created_at",
+    "updated_at",
+  ];
+
+  const rows = profiles.map((p) => {
+    const membership = Array.isArray(p.team_members)
+      ? p.team_members[0]
+      : p.team_members;
+    const team = membership?.team as
+      | { name: string; paid: boolean }
+      | undefined;
+    return [
+      p.id,
+      p.full_name,
+      p.email,
+      p.phone,
+      p.user_type,
+      p.zid,
+      p.uni_id,
+      p.university,
+      p.high_school,
+      p.year_of_study,
+      p.degree_stage,
+      p.undergrad_postgrad,
+      p.domestic_international,
+      p.degree,
+      p.majors,
+      p.faculty,
+      p.gender,
+      p.gender_other,
+      p.is_ramsoc_member,
+      p.is_arc_member,
+      p.heard_from,
+      p.heard_from_other,
+      p.onboarded,
+      team?.name ?? "",
+      membership?.team_id ?? "",
+      membership?.role ?? "",
+      team?.paid ?? "",
+      p.created_at,
+      p.updated_at,
+    ];
+  });
+
+  const csv = toCSV(headers, rows);
+  const date = new Date().toISOString().slice(0, 10);
+
+  return new NextResponse(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="participants-${date}.csv"`,
+    },
+  });
+}

--- a/src/app/2026/admin/api/export/teams/route.ts
+++ b/src/app/2026/admin/api/export/teams/route.ts
@@ -1,0 +1,98 @@
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { getSupabaseSecretClient } from "@/app/_utils/supabase";
+import type { Profile } from "@/app/_types/registration";
+
+function escapeCell(value: unknown): string {
+  const str = value === null || value === undefined ? "" : String(value);
+  if (str.includes(",") || str.includes('"') || str.includes("\n")) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+function toCSV(headers: string[], rows: unknown[][]): string {
+  return [headers, ...rows]
+    .map((row) => row.map(escapeCell).join(","))
+    .join("\n");
+}
+
+type MemberRow = {
+  id: string;
+  team_id: string;
+  profile_id: string;
+  role: "captain" | "member";
+  joined_at: string;
+  profile: Profile;
+};
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const session = cookieStore.get("admin_session");
+  if (session?.value !== "authenticated") {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const supabase = getSupabaseSecretClient();
+
+  const { data: teams } = await supabase
+    .from("teams")
+    .select("*, team_members(id, team_id, profile_id, role, joined_at, profile:profiles(*))")
+    .eq("competition_year", 2026)
+    .order("created_at", { ascending: false });
+
+  if (!teams) {
+    return new NextResponse("Failed to fetch data", { status: 500 });
+  }
+
+  const headers = [
+    "id",
+    "name",
+    "category",
+    "join_code",
+    "paid",
+    "member_count",
+    "captain_name",
+    "captain_email",
+    "captain_zid",
+    "member_names",
+    "member_emails",
+    "created_at",
+    "updated_at",
+  ];
+
+  const rows = teams.map((t) => {
+    const members: MemberRow[] = Array.isArray(t.team_members)
+      ? (t.team_members as MemberRow[])
+      : [];
+    const captain = members.find((m) => m.role === "captain");
+    const memberNames = members.map((m) => m.profile.full_name).join("; ");
+    const memberEmails = members.map((m) => m.profile.email).join("; ");
+
+    return [
+      t.id,
+      t.name,
+      t.category,
+      t.join_code,
+      t.paid,
+      members.length,
+      captain?.profile.full_name ?? "",
+      captain?.profile.email ?? "",
+      captain?.profile.zid ?? "",
+      memberNames,
+      memberEmails,
+      t.created_at,
+      t.updated_at,
+    ];
+  });
+
+  const csv = toCSV(headers, rows);
+  const date = new Date().toISOString().slice(0, 10);
+
+  return new NextResponse(csv, {
+    headers: {
+      "Content-Type": "text/csv; charset=utf-8",
+      "Content-Disposition": `attachment; filename="teams-${date}.csv"`,
+    },
+  });
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,7 @@ const isProtectedRoute = createRouteMatcher([
 const isAdminProtectedRoute = createRouteMatcher([
   "/2026/admin/teams(.*)",
   "/2026/admin/individuals(.*)",
+  "/2026/admin/api(.*)",
 ]);
 
 export default clerkMiddleware(async (auth, req) => {


### PR DESCRIPTION
## Description

Add admin export functionality to download participant and team data as CSV files. This includes two new API endpoints that fetch data from Supabase and format it as downloadable CSV files, along with UI buttons in the admin dashboard to trigger these exports.

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

## Changes

### New API Endpoints
- **`/2026/admin/api/export/participants`**: Exports all participant profiles with their team associations as CSV
- **`/2026/admin/api/export/teams`**: Exports all teams with member details and captain information as CSV

Both endpoints:
- Require admin session authentication
- Include proper CSV escaping for special characters (commas, quotes, newlines)
- Return files with date-stamped filenames (e.g., `participants-2024-01-15.csv`)

### Admin Dashboard Updates
- Added export buttons to the admin shell header for quick access to both CSV exports
- Styled to match existing admin UI with hover effects
- Positioned alongside the logout button

### Security & Middleware
- Updated middleware to protect the new `/2026/admin/api` routes with admin authentication

## Test Plan

- Verify both export endpoints return 401 when accessed without valid admin session
- Verify CSV files download with correct filenames and date stamps
- Verify CSV data is properly escaped (test with names/emails containing commas or quotes)
- Verify export buttons are visible in admin dashboard and trigger downloads
- Verify team and participant relationships are correctly represented in exports

https://claude.ai/code/session_019QARXRkiW7LYt5is6vjQ1L