### PR TITLE
feat(admin): per-category season phase locks for Standard and Open divisions

### DIFF
--- a/src/app/2026/_actions/appConfig.ts
+++ b/src/app/2026/_actions/appConfig.ts
@@ -4,23 +4,34 @@ import { getSupabaseSecretClient } from "@/app/_utils/supabase";
 import { REGISTRATION } from "@/app/2026/_data/registrationConfig";
 
 export type AppConfig = {
-  season_phase: "preseason" | "midseason";
+  standard_phase: "preseason" | "midseason";
+  open_phase: "preseason" | "midseason";
   standard_closes: Date;
   open_closes: Date;
   payment_deadline: Date;
 };
 
+export function isCategoryLocked(
+  config: AppConfig,
+  category: "standard" | "open",
+): boolean {
+  return category === "standard"
+    ? config.standard_phase === "midseason"
+    : config.open_phase === "midseason";
+}
+
 export async function getAppConfig(): Promise<AppConfig> {
   const supabase = getSupabaseSecretClient();
   const { data } = await supabase
     .from("app_config")
-    .select("season_phase, standard_closes, open_closes, payment_deadline")
+    .select("standard_phase, open_phase, standard_closes, open_closes, payment_deadline")
     .eq("competition_year", 2026)
     .single();
 
   if (!data) {
     return {
-      season_phase: "preseason",
+      standard_phase: "preseason",
+      open_phase: "preseason",
       standard_closes: REGISTRATION.standardCloses,
       open_closes: REGISTRATION.openCloses,
       payment_deadline: REGISTRATION.paymentDeadline,
@@ -28,14 +39,10 @@ export async function getAppConfig(): Promise<AppConfig> {
   }
 
   return {
-    season_phase: data.season_phase as "preseason" | "midseason",
+    standard_phase: data.standard_phase as "preseason" | "midseason",
+    open_phase: data.open_phase as "preseason" | "midseason",
     standard_closes: new Date(data.standard_closes),
     open_closes: new Date(data.open_closes),
     payment_deadline: new Date(data.payment_deadline),
   };
-}
-
-export async function isMidseason(): Promise<boolean> {
-  const config = await getAppConfig();
-  return config.season_phase === "midseason";
 }

--- a/src/app/2026/_actions/team.ts
+++ b/src/app/2026/_actions/team.ts
@@ -37,7 +37,7 @@ function generateJoinCode(): string {
 }
 
 import { MEMBER_LIMITS } from "@/app/2026/_data/teamConfig";
-import { getAppConfig } from "@/app/2026/_actions/appConfig";
+import { getAppConfig, isCategoryLocked } from "@/app/2026/_actions/appConfig";
 
 async function getProfileId(userId: string) {
   const supabase = getSupabaseSecretClient();
@@ -57,7 +57,7 @@ export async function createTeam(input: {
   if (!userId) return { success: false, error: "Not authenticated" };
 
   const config = await getAppConfig();
-  if (config.season_phase === "midseason") {
+  if (isCategoryLocked(config, input.category)) {
     return { success: false, error: "Team registration is locked — the competition season has begun" };
   }
 
@@ -198,9 +198,6 @@ export async function joinTeam(
   if (!userId) return { success: false, error: "Not authenticated" };
 
   const config = await getAppConfig();
-  if (config.season_phase === "midseason") {
-    return { success: false, error: "Team registration is locked — the competition season has begun" };
-  }
 
   const code = joinCode.trim().toUpperCase();
   if (code.length !== 6) {
@@ -234,6 +231,10 @@ export async function joinTeam(
 
   if (!team) {
     return { success: false, error: "Invalid join code" };
+  }
+
+  if (isCategoryLocked(config, team.category as "standard" | "open")) {
+    return { success: false, error: "Team registration is locked — the competition season has begun" };
   }
 
   // Enforce Standard category restriction: only UNSW students allowed
@@ -282,9 +283,6 @@ export async function leaveTeam(): Promise<{
   if (!userId) return { success: false, error: "Not authenticated" };
 
   const config = await getAppConfig();
-  if (config.season_phase === "midseason") {
-    return { success: false, error: "Teams are locked — the competition season has begun" };
-  }
 
   const profileId = await getProfileId(userId);
   if (!profileId) return { success: false, error: "Profile not found" };
@@ -294,13 +292,18 @@ export async function leaveTeam(): Promise<{
   // Find membership
   const { data: membership } = await supabase
     .from("team_members")
-    .select("id, team_id, role")
+    .select("id, team_id, role, teams(category)")
     .eq("profile_id", profileId)
     .limit(1)
     .single();
 
   if (!membership) {
     return { success: false, error: "You are not on a team" };
+  }
+
+  const teamCategory = (membership.teams as { category: string } | null)?.category as "standard" | "open" | undefined;
+  if (teamCategory && isCategoryLocked(config, teamCategory)) {
+    return { success: false, error: "Teams are locked — the competition season has begun" };
   }
 
   if (membership.role === "captain") {
@@ -520,9 +523,6 @@ export async function kickMember(
   if (!userId) return { success: false, error: "Not authenticated" };
 
   const config = await getAppConfig();
-  if (config.season_phase === "midseason") {
-    return { success: false, error: "Teams are locked — the competition season has begun" };
-  }
 
   const profileId = await getProfileId(userId);
   if (!profileId) return { success: false, error: "Profile not found" };
@@ -532,11 +532,16 @@ export async function kickMember(
   // Verify target exists
   const { data: target } = await supabase
     .from("team_members")
-    .select("id, team_id, profile_id, role")
+    .select("id, team_id, profile_id, role, teams(category)")
     .eq("id", teamMemberId)
     .single();
 
   if (!target) return { success: false, error: "Member not found" };
+
+  const kickTeamCategory = (target.teams as { category: string } | null)?.category as "standard" | "open" | undefined;
+  if (kickTeamCategory && isCategoryLocked(config, kickTeamCategory)) {
+    return { success: false, error: "Teams are locked — the competition season has begun" };
+  }
 
   if (target.profile_id === profileId) {
     return { success: false, error: "You cannot kick yourself" };

--- a/src/app/2026/admin/_actions/config.ts
+++ b/src/app/2026/admin/_actions/config.ts
@@ -17,29 +17,32 @@ export async function getAdminAppConfig(): Promise<AppConfig> {
   const supabase = getSupabaseSecretClient();
   const { data } = await supabase
     .from("app_config")
-    .select("season_phase, standard_closes, open_closes, payment_deadline")
+    .select("standard_phase, open_phase, standard_closes, open_closes, payment_deadline")
     .eq("competition_year", 2026)
     .single();
 
   if (!data) throw new Error("App config not found");
 
   return {
-    season_phase: data.season_phase as "preseason" | "midseason",
+    standard_phase: data.standard_phase as "preseason" | "midseason",
+    open_phase: data.open_phase as "preseason" | "midseason",
     standard_closes: new Date(data.standard_closes),
     open_closes: new Date(data.open_closes),
     payment_deadline: new Date(data.payment_deadline),
   };
 }
 
-export async function updateSeasonPhase(
+export async function updateCategoryPhase(
+  category: "standard" | "open",
   phase: "preseason" | "midseason",
 ): Promise<{ success: boolean; error?: string }> {
   await assertAdmin();
   const supabase = getSupabaseSecretClient();
 
+  const field = category === "standard" ? "standard_phase" : "open_phase";
   const { error } = await supabase
     .from("app_config")
-    .update({ season_phase: phase, updated_at: new Date().toISOString() })
+    .update({ [field]: phase, updated_at: new Date().toISOString() })
     .eq("competition_year", 2026);
 
   if (error) return { success: false, error: error.message };

--- a/src/app/2026/admin/_components/SettingsPanel.tsx
+++ b/src/app/2026/admin/_components/SettingsPanel.tsx
@@ -5,17 +5,62 @@ import { useRouter } from "next/navigation";
 import { Button } from "@/app/2026/_components/ui/Button";
 import Badge from "@/app/2026/_components/ui/Badge";
 import {
-  updateSeasonPhase,
+  updateCategoryPhase,
   updateRegistrationDates,
 } from "@/app/2026/admin/_actions/config";
 import type { AppConfig } from "@/app/2026/_actions/appConfig";
 
 function toLocalDatetimeValue(date: Date): string {
-  // Returns "YYYY-MM-DDTHH:mm" in local time for datetime-local inputs
   const pad = (n: number) => String(n).padStart(2, "0");
   return (
     `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
     `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
+}
+
+function PhaseToggle({
+  label,
+  description,
+  phase,
+  onToggle,
+  isPending,
+}: {
+  label: string;
+  description: string;
+  phase: "preseason" | "midseason";
+  onToggle: (next: "preseason" | "midseason") => void;
+  isPending: boolean;
+}) {
+  const isMid = phase === "midseason";
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/20 p-4">
+      <div className="mb-3">
+        <p className="font-main text-sm font-semibold text-white">{label}</p>
+        <p className="font-main mt-0.5 text-xs text-gray-400">{description}</p>
+      </div>
+      <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-black/30 px-3 py-2">
+          <span className="font-main text-xs text-gray-400">Current:</span>
+          <Badge variant={isMid ? "warning" : "success"}>
+            {isMid ? "Midseason" : "Preseason"}
+          </Badge>
+        </div>
+        <Button
+          variant={isMid ? "secondary" : "primary"}
+          size="default"
+          onClick={() => onToggle(isMid ? "preseason" : "midseason")}
+          disabled={isPending}
+        >
+          {isPending ? "Saving…" : isMid ? "Unlock teams" : "Lock teams"}
+        </Button>
+      </div>
+      {isMid && (
+        <p className="font-main mt-2 text-xs text-amber-400">
+          Teams are locked. Participants cannot join, leave, or create{" "}
+          {label.toLowerCase()} teams.
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -40,21 +85,23 @@ export default function SettingsPanel({ config }: { config: AppConfig }) {
     setTimeout(() => setSuccess(null), 3000);
   }
 
-  function handleTogglePhase() {
-    const newPhase =
-      config.season_phase === "preseason" ? "midseason" : "preseason";
+  function handleTogglePhase(
+    category: "standard" | "open",
+    next: "preseason" | "midseason",
+  ) {
     startTransition(async () => {
       setError(null);
-      const result = await updateSeasonPhase(newPhase);
+      const result = await updateCategoryPhase(category, next);
       if (result.success) {
+        const label = category === "standard" ? "Standard" : "Open";
         notify(
-          newPhase === "midseason"
-            ? "Switched to midseason — teams are now locked."
-            : "Switched to preseason — teams are now open.",
+          next === "midseason"
+            ? `${label} teams locked (midseason).`
+            : `${label} teams unlocked (preseason).`,
         );
         router.refresh();
       } else {
-        setError(result.error ?? "Failed to update season phase");
+        setError(result.error ?? "Failed to update phase");
       }
     });
   }
@@ -76,8 +123,6 @@ export default function SettingsPanel({ config }: { config: AppConfig }) {
     });
   }
 
-  const isMidseason = config.season_phase === "midseason";
-
   return (
     <div className="flex flex-col gap-8 max-w-2xl">
       {error && (
@@ -91,44 +136,33 @@ export default function SettingsPanel({ config }: { config: AppConfig }) {
         </p>
       )}
 
-      {/* Season phase toggle */}
+      {/* Season phase toggles */}
       <section className="rounded-lg border border-white/10 bg-white/5 p-6">
         <h3 className="font-main mb-1 text-base font-semibold text-white">
           Season Phase
         </h3>
         <p className="font-main mb-4 text-sm text-gray-400">
-          Toggle between preseason (teams open) and midseason (teams locked).
-          When midseason is active, participants cannot join, leave, or create
-          teams. Admin actions are unaffected.
+          Lock or unlock teams per division. When midseason is active for a
+          division, participants cannot join, leave, or create teams in that
+          division. Admin actions are always unaffected.
         </p>
 
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-black/30 px-4 py-3">
-            <span className="font-main text-sm text-gray-300">Current:</span>
-            <Badge variant={isMidseason ? "warning" : "success"}>
-              {isMidseason ? "Midseason" : "Preseason"}
-            </Badge>
-          </div>
-          <Button
-            variant={isMidseason ? "secondary" : "primary"}
-            size="default"
-            onClick={handleTogglePhase}
-            disabled={isPending}
-          >
-            {isPending
-              ? "Saving..."
-              : isMidseason
-              ? "Switch to Preseason"
-              : "Switch to Midseason"}
-          </Button>
+        <div className="flex flex-col gap-3">
+          <PhaseToggle
+            label="Standard (UNSW-only)"
+            description="Controls team locking for the Standard division."
+            phase={config.standard_phase}
+            onToggle={(next) => handleTogglePhase("standard", next)}
+            isPending={isPending}
+          />
+          <PhaseToggle
+            label="Open (inter-uni)"
+            description="Controls team locking for the Open division."
+            phase={config.open_phase}
+            onToggle={(next) => handleTogglePhase("open", next)}
+            isPending={isPending}
+          />
         </div>
-
-        {isMidseason && (
-          <p className="font-main mt-3 text-xs text-amber-400">
-            Teams are currently locked. Participants cannot join, leave, or create
-            teams.
-          </p>
-        )}
       </section>
 
       {/* Registration date controls */}
@@ -185,7 +219,7 @@ export default function SettingsPanel({ config }: { config: AppConfig }) {
             disabled={isPending}
             className="self-start"
           >
-            {isPending ? "Saving..." : "Save Dates"}
+            {isPending ? "Saving…" : "Save Dates"}
           </Button>
         </div>
       </section>

--- a/supabase/migrations/008_split_season_phase.sql
+++ b/supabase/migrations/008_split_season_phase.sql
@@ -1,0 +1,15 @@
+-- Split season_phase into separate controls per registration category.
+-- standard_phase locks Standard (UNSW-only) teams; open_phase locks Open teams.
+
+ALTER TABLE app_config
+  ADD COLUMN standard_phase TEXT NOT NULL DEFAULT 'preseason'
+    CHECK (standard_phase IN ('preseason', 'midseason')),
+  ADD COLUMN open_phase TEXT NOT NULL DEFAULT 'preseason'
+    CHECK (open_phase IN ('preseason', 'midseason'));
+
+-- Migrate existing value so nothing breaks on upgrade.
+UPDATE app_config SET
+  standard_phase = season_phase,
+  open_phase     = season_phase;
+
+ALTER TABLE app_config DROP COLUMN season_phase;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces the single `season_phase` toggle with separate **Standard** and **Open** phase controls in the admin Settings panel
- Each division can be independently switched between preseason (teams open) and midseason (teams locked)
- Adds DB migration `008_split_season_phase.sql` that renames `season_phase` → `standard_phase` + `open_phase`, migrating existing values
- Team actions (`createTeam`, `joinTeam`, `leaveTeam`, `kickMember`) now check the lock for the relevant category only
- Admin actions remain unrestricted regardless of phase

## Migration note

`supabase/migrations/008_split_season_phase.sql` must be applied to your Supabase instance before deploying. It migrates the existing `season_phase` column value into both `standard_phase` and `open_phase`.

## Test plan

- [ ] Admin settings page shows two separate phase toggles (Standard and Open)
- [ ] Locking Standard teams prevents join/leave/create for standard teams but not open teams
- [ ] Locking Open teams prevents join/leave/create for open teams but not standard teams
- [ ] Admin panel can still move members and delete teams regardless of phase
- [ ] Registration date controls still save correctly

https://claude.ai/code/session_018NnbSrEmieMwi1SNkKv7Ne
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_018NnbSrEmieMwi1SNkKv7Ne)_