### PR TITLE
fix(admin): resolve build error from per-category season phase

### DIFF
--- a/src/app/2026/_actions/appConfig.ts
+++ b/src/app/2026/_actions/appConfig.ts
@@ -11,15 +11,6 @@ export type AppConfig = {
   payment_deadline: Date;
 };
 
-export function isCategoryLocked(
-  config: AppConfig,
-  category: "standard" | "open",
-): boolean {
-  return category === "standard"
-    ? config.standard_phase === "midseason"
-    : config.open_phase === "midseason";
-}
-
 export async function getAppConfig(): Promise<AppConfig> {
   const supabase = getSupabaseSecretClient();
   const { data } = await supabase

--- a/src/app/2026/_actions/team.ts
+++ b/src/app/2026/_actions/team.ts
@@ -37,7 +37,8 @@ function generateJoinCode(): string {
 }
 
 import { MEMBER_LIMITS } from "@/app/2026/_data/teamConfig";
-import { getAppConfig, isCategoryLocked } from "@/app/2026/_actions/appConfig";
+import { getAppConfig } from "@/app/2026/_actions/appConfig";
+import { isCategoryLocked } from "@/app/2026/_utils/seasonPhase";
 
 async function getProfileId(userId: string) {
   const supabase = getSupabaseSecretClient();
@@ -301,7 +302,8 @@ export async function leaveTeam(): Promise<{
     return { success: false, error: "You are not on a team" };
   }
 
-  const teamCategory = (membership.teams as { category: string } | null)?.category as "standard" | "open" | undefined;
+  const teamsData = membership.teams as unknown as { category: string } | { category: string }[] | null;
+  const teamCategory = (Array.isArray(teamsData) ? teamsData[0]?.category : teamsData?.category) as "standard" | "open" | undefined;
   if (teamCategory && isCategoryLocked(config, teamCategory)) {
     return { success: false, error: "Teams are locked — the competition season has begun" };
   }
@@ -538,7 +540,8 @@ export async function kickMember(
 
   if (!target) return { success: false, error: "Member not found" };
 
-  const kickTeamCategory = (target.teams as { category: string } | null)?.category as "standard" | "open" | undefined;
+  const kickTeamsData = target.teams as unknown as { category: string } | { category: string }[] | null;
+  const kickTeamCategory = (Array.isArray(kickTeamsData) ? kickTeamsData[0]?.category : kickTeamsData?.category) as "standard" | "open" | undefined;
   if (kickTeamCategory && isCategoryLocked(config, kickTeamCategory)) {
     return { success: false, error: "Teams are locked — the competition season has begun" };
   }

--- a/src/app/2026/_utils/seasonPhase.ts
+++ b/src/app/2026/_utils/seasonPhase.ts
@@ -1,0 +1,10 @@
+import type { AppConfig } from "@/app/2026/_actions/appConfig";
+
+export function isCategoryLocked(
+  config: AppConfig,
+  category: "standard" | "open",
+): boolean {
+  return category === "standard"
+    ? config.standard_phase === "midseason"
+    : config.open_phase === "midseason";
+}


### PR DESCRIPTION
## Summary

- Moves `isCategoryLocked` helper out of the `"use server"` file (`appConfig.ts`) into `src/app/2026/_utils/seasonPhase.ts` — Next.js/Turbopack requires all exports from `"use server"` files to be async functions
- Fixes TypeScript type errors on Supabase join results in `leaveTeam` and `kickMember` (joined relations are returned as arrays, not objects)
- Build now passes cleanly

Fixes the build failure introduced by #210.

https://claude.ai/code/session_018NnbSrEmieMwi1SNkKv7Ne

---
_Generated by [Claude Code](https://claude.ai/code/session_018NnbSrEmieMwi1SNkKv7Ne)_