### PR TITLE
fix: bypass Worker body limit for large image uploads via Supabase signed URLs

### DIFF
--- a/src/app/2026/blog/_components/BioEditor.tsx
+++ b/src/app/2026/blog/_components/BioEditor.tsx
@@ -6,7 +6,7 @@ import Card from "@/app/2026/_components/ui/Card";
 import { Button } from "@/app/2026/_components/ui/Button";
 import Input from "@/app/2026/_components/ui/Input";
 import { TeamAvatar } from "./teamProfile";
-import { uploadPostImage } from "../_utils/uploadImage";
+import { getUploadUrl } from "../_utils/uploadImage";
 import { updateBlogProfile } from "../_actions/blog";
 import type { BlogTeamProfile } from "../_types";
 
@@ -41,10 +41,18 @@ export default function BioEditor({
     const file = e.target.files?.[0];
     if (!file) return;
     setUploading(true);
-    const fd = new FormData();
-    fd.append("file", file);
-    const { url } = await uploadPostImage(fd);
-    if (url) setAvatarUrl(url);
+    const { signedUrl, publicUrl, error } = await getUploadUrl(file.name, file.type);
+    if (signedUrl && publicUrl) {
+      const res = await fetch(signedUrl, {
+        method: "PUT",
+        body: file,
+        headers: { "Content-Type": file.type },
+      });
+      if (res.ok) setAvatarUrl(publicUrl);
+      else setError("Upload failed, please try again");
+    } else {
+      setError(error ?? "Couldn't start upload");
+    }
     setUploading(false);
   }
 

--- a/src/app/2026/blog/_components/PostComposer.tsx
+++ b/src/app/2026/blog/_components/PostComposer.tsx
@@ -5,7 +5,7 @@ import { useRef, useState } from "react";
 import { LuImagePlus, LuX } from "react-icons/lu";
 import Card from "@/app/2026/_components/ui/Card";
 import { Button } from "@/app/2026/_components/ui/Button";
-import { uploadPostImage } from "../_utils/uploadImage";
+import { getUploadUrl } from "../_utils/uploadImage";
 import type { BlogPost, BlogTeamProfile } from "../_types";
 
 /**
@@ -36,10 +36,15 @@ export default function PostComposer({
     const file = e.target.files?.[0];
     if (!file) return;
     setUploading(true);
-    const fd = new FormData();
-    fd.append("file", file);
-    const { url } = await uploadPostImage(fd);
-    if (url) setImageUrl(url);
+    const { signedUrl, publicUrl } = await getUploadUrl(file.name, file.type);
+    if (signedUrl && publicUrl) {
+      const res = await fetch(signedUrl, {
+        method: "PUT",
+        body: file,
+        headers: { "Content-Type": file.type },
+      });
+      if (res.ok) setImageUrl(publicUrl);
+    }
     setUploading(false);
   }
 

--- a/src/app/2026/blog/_utils/uploadImage.ts
+++ b/src/app/2026/blog/_utils/uploadImage.ts
@@ -1,37 +1,47 @@
 "use server";
 
-// Uploads an image to the public Supabase Storage bucket "blog-images" and
-// returns its public URL. Called from client components by POSTing FormData
-// (a File can't cross the server-action boundary as a bare argument).
+// Generates a short-lived Supabase signed upload URL so the browser can PUT
+// the file directly to Supabase Storage without routing it through the
+// Cloudflare Worker (which has a ~4 MB server-action body limit).
+//
+// Flow:
+//   1. Client calls getUploadUrl(filename, contentType) — tiny request.
+//   2. Server generates a UUID path + signed URL and returns both.
+//   3. Client PUTs the file to signedUrl.
+//   4. Client uses publicUrl as the stored image URL.
 //
 // Setup: create a PUBLIC bucket named "blog-images" in the Supabase dashboard.
-// The bucket host is already allowed in next.config.ts -> images.remotePatterns.
 
 import { auth } from "@clerk/nextjs/server";
 import { getSupabaseSecretClient } from "@/app/_utils/supabase";
 
-export type UploadResult = { url: string | null; error: string | null };
-
 const BUCKET = "blog-images";
 
-export async function uploadPostImage(
-  formData: FormData,
-): Promise<UploadResult> {
-  const { userId } = await auth();
-  if (!userId) return { url: null, error: "Not authenticated" };
+export type UploadUrlResult = {
+  signedUrl: string | null;
+  publicUrl: string | null;
+  error: string | null;
+};
 
-  const file = formData.get("file");
-  if (!(file instanceof File)) return { url: null, error: "No file provided" };
+export async function getUploadUrl(
+  filename: string,
+  contentType: string,
+): Promise<UploadUrlResult> {
+  const { userId } = await auth();
+  if (!userId) return { signedUrl: null, publicUrl: null, error: "Not authenticated" };
 
   const supabase = getSupabaseSecretClient();
-  const ext = file.name.split(".").pop()?.toLowerCase() || "jpg";
+  const ext = filename.split(".").pop()?.toLowerCase() || "jpg";
   const path = `${userId}/${crypto.randomUUID()}.${ext}`;
 
-  const { error } = await supabase.storage
+  const { data, error } = await supabase.storage
     .from(BUCKET)
-    .upload(path, file, { contentType: file.type, upsert: false });
-  if (error) return { url: null, error: error.message };
+    .createSignedUploadUrl(path);
 
-  const { data } = supabase.storage.from(BUCKET).getPublicUrl(path);
-  return { url: data.publicUrl, error: null };
+  if (error || !data) {
+    return { signedUrl: null, publicUrl: null, error: error?.message ?? "Failed to create upload URL" };
+  }
+
+  const { data: urlData } = supabase.storage.from(BUCKET).getPublicUrl(path);
+  return { signedUrl: data.signedUrl, publicUrl: urlData.publicUrl, error: null };
 }


### PR DESCRIPTION
## Summary

- Image uploads (~10 MB) were failing on prod because Next.js server actions have a ~4 MB default body size limit on Cloudflare Workers — the file was being routed through the Worker before reaching Supabase
- Replaced the server-proxied upload (`uploadPostImage`) with a signed-URL pattern (`getUploadUrl`): the server action now only generates a short-lived Supabase signed upload URL, and the browser PUTs the file directly to Supabase Storage
- Applied to both `PostComposer` (post images) and `BioEditor` (team avatars); `BioEditor` also now surfaces upload errors to the existing error state

## How it works now

1. User picks a file → browser calls `getUploadUrl(filename, contentType)` (tiny ~100 byte server action request, just auth + UUID path generation)
2. Server returns a short-lived signed URL + the final public URL
3. Browser `PUT`s the file directly to Supabase — **no file data ever touches the Cloudflare Worker**
4. On success, the public URL is stored as normal

## Test plan

- [ ] Upload a ~10 MB image as a post photo — should succeed where it previously failed
- [ ] Upload a ~10 MB image as a team avatar — should succeed
- [ ] Upload a small image — still works as before
- [ ] Unauthenticated user cannot obtain a signed URL (server action returns error)

https://claude.ai/code/session_017aU2jxinQH9Nvb7FhW8dnC

---
_Generated by [Claude Code](https://claude.ai/code/session_017aU2jxinQH9Nvb7FhW8dnC)_