### PR TITLE
feat(blog): collapsed bio editor, clickable team headers, team profile pages

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://sumobots.ramsocunsw.org/2024</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2024/resources</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2025</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2025/team</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2025/workshop</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2026</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2026/admin</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2026/blog</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2026/blog/manage</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2026/team</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2026/ui</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/2026/workshop</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://sumobots.ramsocunsw.org/manifest.json</loc><lastmod>2026-06-16T08:55:37.572Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2024</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2024/resources</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2025</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2025/team</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2025/workshop</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2026</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2026/admin</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2026/blog</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2026/blog/manage</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2026/team</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2026/ui</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/2026/workshop</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://sumobots.ramsocunsw.org/manifest.json</loc><lastmod>2026-06-16T09:04:43.153Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/app/2026/blog/_components/BioEditor.tsx
+++ b/src/app/2026/blog/_components/BioEditor.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { LuImagePlus } from "react-icons/lu";
+import { LuImagePlus, LuPencil } from "react-icons/lu";
 import Card from "@/app/2026/_components/ui/Card";
 import { Button } from "@/app/2026/_components/ui/Button";
 import Input from "@/app/2026/_components/ui/Input";
+import Badge from "@/app/2026/_components/ui/Badge";
 import { TeamAvatar } from "./teamProfile";
 import { getUploadUrl } from "../_utils/uploadImage";
 import { updateBlogProfile } from "../_actions/blog";
@@ -13,8 +14,9 @@ import type { BlogTeamProfile } from "../_types";
 /**
  * Edit the team's shared blog profile: avatar, robot name and bio.
  *
- * The team name is fixed (sourced from `teams.name`) and shown read-only — it
- * is never sent to `updateBlogProfile`. Any member of the team can save here.
+ * Starts collapsed when the profile already has a robot name; expands to the
+ * full form when the user clicks "Edit profile". After saving it collapses
+ * back automatically.
  */
 export default function BioEditor({
   team,
@@ -23,6 +25,7 @@ export default function BioEditor({
   team: BlogTeamProfile;
   onSave: (updated: BlogTeamProfile) => void;
 }) {
+  const [editing, setEditing] = useState(!team.robotName);
   const [robotName, setRobotName] = useState(team.robotName);
   const [bio, setBio] = useState(team.bio);
   const [avatarUrl, setAvatarUrl] = useState(team.avatarUrl);
@@ -41,7 +44,10 @@ export default function BioEditor({
     const file = e.target.files?.[0];
     if (!file) return;
     setUploading(true);
-    const { signedUrl, publicUrl, error } = await getUploadUrl(file.name, file.type);
+    const { signedUrl, publicUrl, error } = await getUploadUrl(
+      file.name,
+      file.type,
+    );
     if (signedUrl && publicUrl) {
       const res = await fetch(signedUrl, {
         method: "PUT",
@@ -67,12 +73,53 @@ export default function BioEditor({
     }
     onSave({ ...team, robotName, bio, avatarUrl });
     setSaved(true);
-    setTimeout(() => setSaved(false), 1500);
+    setTimeout(() => {
+      setSaved(false);
+      setEditing(false);
+    }, 1000);
   }
 
+  // ── Collapsed view ──────────────────────────────────────────────────────────
+  if (!editing) {
+    return (
+      <Card className="flex items-center gap-3 p-4">
+        <TeamAvatar team={{ teamName: team.teamName, avatarUrl }} size={48} />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="flex items-center gap-2">
+            <span className="font-main truncate text-sm font-semibold text-white">
+              {team.teamName}
+            </span>
+            <Badge variant={team.category === "open" ? "info" : "default"}>
+              {team.category}
+            </Badge>
+          </div>
+          <span className="font-main truncate text-xs text-rose-400">
+            {robotName || "No robot name yet"}
+          </span>
+        </div>
+        <Button variant="secondary" onClick={() => setEditing(true)}>
+          <LuPencil className="h-4 w-4" />
+          Edit profile
+        </Button>
+      </Card>
+    );
+  }
+
+  // ── Expanded / editing view ─────────────────────────────────────────────────
   return (
     <Card className="flex flex-col gap-5">
-      <h3 className="text-lg font-semibold text-white">Team profile</h3>
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold text-white">Team profile</h3>
+        {team.robotName && (
+          <button
+            type="button"
+            onClick={() => setEditing(false)}
+            className="font-main text-xs text-gray-500 transition-colors hover:text-gray-300"
+          >
+            Cancel
+          </button>
+        )}
+      </div>
 
       <div className="flex items-center gap-4">
         <TeamAvatar team={{ teamName: team.teamName, avatarUrl }} size={72} />
@@ -133,9 +180,7 @@ export default function BioEditor({
         </span>
       </div>
 
-      {error && (
-        <p className="font-main text-sm text-rose-400">{error}</p>
-      )}
+      {error && <p className="font-main text-sm text-rose-400">{error}</p>}
 
       <Button
         onClick={handleSave}

--- a/src/app/2026/blog/_components/post.tsx
+++ b/src/app/2026/blog/_components/post.tsx
@@ -2,6 +2,7 @@
 
 import { useUser } from "@clerk/nextjs";
 import Image from "next/image";
+import Link from "next/link";
 import { useState } from "react";
 import { LuHeart, LuMessageCircle, LuPencil, LuTrash2 } from "react-icons/lu";
 import Card from "@/app/2026/_components/ui/Card";
@@ -106,15 +107,20 @@ export default function Post({
     <Card className="overflow-hidden p-0">
       {/* Header */}
       <div className="flex items-center gap-3 p-4">
-        <TeamAvatar team={post.team} size={40} />
-        <div className="flex flex-col">
-          <span className="font-main text-sm font-semibold text-white">
-            {post.team.teamName}
-          </span>
-          <span className="font-main text-xs text-gray-400">
-            {post.team.robotName} · {timeAgo(post.createdAt)}
-          </span>
-        </div>
+        <Link
+          href={`/2026/blog/team/${post.team.teamId}`}
+          className="flex items-center gap-3 transition-opacity hover:opacity-80"
+        >
+          <TeamAvatar team={post.team} size={40} />
+          <div className="flex flex-col">
+            <span className="font-main text-sm font-semibold text-white">
+              {post.team.teamName}
+            </span>
+            <span className="font-main text-xs text-gray-400">
+              {post.team.robotName} · {timeAgo(post.createdAt)}
+            </span>
+          </div>
+        </Link>
         {owned && (
           <div className="ml-auto flex items-center gap-1">
             <button

--- a/src/app/2026/blog/team/[teamId]/page.tsx
+++ b/src/app/2026/blog/team/[teamId]/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import { Fragment, useEffect, useState } from "react";
+import Link from "next/link";
+import { LuArrowLeft } from "react-icons/lu";
+import Navbar from "../../../_components/Nav/Navbar";
+import Footer from "../../../_components/Footer";
+import FadeIn from "../../../_components/ui/FadeIn";
+import Card from "../../../_components/ui/Card";
+import Badge from "../../../_components/ui/Badge";
+import Post from "../../_components/post";
+import { TeamAvatar } from "../../_components/teamProfile";
+import { getBlogProfile, getTeamPosts } from "../../_actions/blog";
+import type { BlogPostWithTeam, BlogTeamProfile } from "../../_types";
+
+export default function TeamProfilePage({
+  params,
+}: {
+  params: { teamId: string };
+}) {
+  const [isFooterVisible, setFooterVisible] = useState(false);
+  const [team, setTeam] = useState<BlogTeamProfile | null>(null);
+  const [posts, setPosts] = useState<BlogPostWithTeam[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const [profile, teamPosts] = await Promise.all([
+        getBlogProfile(params.teamId),
+        getTeamPosts(params.teamId),
+      ]);
+      if (!profile) {
+        setNotFound(true);
+      } else {
+        setTeam(profile);
+        setPosts(teamPosts);
+      }
+      setLoading(false);
+    })();
+  }, [params.teamId]);
+
+  return (
+    <Fragment>
+      <Navbar isFooterVisible={isFooterVisible} />
+      <section className="min-h-screen py-24">
+        <div className="flex min-h-screen w-full flex-col items-center bg-black/30 px-4 pt-12">
+          <div className="w-full max-w-xl">
+            <Link
+              href="/2026/blog"
+              className="font-main mb-6 inline-flex items-center gap-1.5 text-sm text-gray-400 transition-colors hover:text-white"
+            >
+              <LuArrowLeft className="h-4 w-4" />
+              Back to feed
+            </Link>
+
+            {loading ? (
+              <div className="flex flex-col gap-6">
+                <ProfileSkeleton />
+                <PostSkeleton />
+                <PostSkeleton />
+              </div>
+            ) : notFound ? (
+              <p className="font-main text-sm text-gray-400">
+                Team not found.
+              </p>
+            ) : team ? (
+              <div className="flex flex-col gap-6">
+                <FadeIn>
+                  <TeamProfileCard team={team} postCount={posts.length} />
+                </FadeIn>
+
+                {posts.length > 0 ? (
+                  <>
+                    <h2 className="text-lg font-semibold text-white">
+                      Posts ({posts.length})
+                    </h2>
+                    {posts.map((post, i) => (
+                      <FadeIn key={post.id} delay={Math.min(i * 0.06, 0.3)}>
+                        <Post post={post} />
+                      </FadeIn>
+                    ))}
+                  </>
+                ) : (
+                  <p className="font-main py-8 text-center text-sm text-gray-400">
+                    This team hasn&apos;t posted anything yet.
+                  </p>
+                )}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </section>
+      <Footer setFooterVisible={setFooterVisible} />
+    </Fragment>
+  );
+}
+
+function TeamProfileCard({
+  team,
+  postCount,
+}: {
+  team: BlogTeamProfile;
+  postCount: number;
+}) {
+  return (
+    <Card className="flex flex-col items-center gap-5 py-8 text-center">
+      <TeamAvatar team={team} size={96} />
+      <div className="flex flex-col items-center gap-1.5">
+        <div className="flex items-center gap-2">
+          <h1 className="text-xl font-bold text-white">{team.teamName}</h1>
+          <Badge variant={team.category === "open" ? "info" : "default"}>
+            {team.category}
+          </Badge>
+        </div>
+        {team.robotName && (
+          <p className="font-main text-sm text-rose-400">
+            Building {team.robotName}
+          </p>
+        )}
+        <p className="font-main text-xs text-gray-500">
+          {postCount} {postCount === 1 ? "post" : "posts"}
+        </p>
+      </div>
+      {team.bio && (
+        <p className="font-main max-w-sm text-sm text-gray-300">{team.bio}</p>
+      )}
+    </Card>
+  );
+}
+
+function ProfileSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-xl border border-white/10 bg-white/5 shadow-lg backdrop-blur-xl">
+      <div className="flex flex-col items-center gap-4 py-8">
+        <div className="h-24 w-24 animate-pulse rounded-full bg-white/10" />
+        <div className="flex flex-col items-center gap-2">
+          <div className="h-5 w-36 animate-pulse rounded bg-white/10" />
+          <div className="h-3 w-24 animate-pulse rounded bg-white/10" />
+        </div>
+        <div className="h-3 w-64 animate-pulse rounded bg-white/10" />
+        <div className="h-3 w-48 animate-pulse rounded bg-white/10" />
+      </div>
+    </div>
+  );
+}
+
+function PostSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-xl border border-white/10 bg-white/5 shadow-lg backdrop-blur-xl">
+      <div className="flex items-center gap-3 p-4">
+        <div className="h-10 w-10 animate-pulse rounded-full bg-white/10" />
+        <div className="flex flex-col gap-1.5">
+          <div className="h-3 w-28 animate-pulse rounded bg-white/10" />
+          <div className="h-2.5 w-20 animate-pulse rounded bg-white/10" />
+        </div>
+      </div>
+      <div className="aspect-[4/3] w-full animate-pulse bg-white/10" />
+      <div className="flex flex-col gap-3 p-4">
+        <div className="flex gap-3">
+          <div className="h-5 w-12 animate-pulse rounded bg-white/10" />
+          <div className="h-5 w-12 animate-pulse rounded bg-white/10" />
+        </div>
+        <div className="h-3 w-full animate-pulse rounded bg-white/10" />
+        <div className="h-3 w-2/3 animate-pulse rounded bg-white/10" />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Collapsed BioEditor** — once a team has a robot name set, the profile section on the Manage page collapses to a compact row (avatar, team name, robot name in rose, category badge, "Edit profile" button). Clicking "Edit profile" expands the full form; saving collapses it back automatically.
- **Clickable team headers** — the avatar + team name row on every post card is now a link to that team's profile page (`/2026/blog/team/[teamId]`).
- **Team profile pages** — new page at `/2026/blog/team/[teamId]` showing the team's profile card (avatar, name, robot name, category, bio, post count) followed by all their posts, with skeleton loading while data fetches.

## Test plan

- [ ] Go to Manage page as a team with a robot name set → profile section should show collapsed compact row
- [ ] Click "Edit profile" → full form expands
- [ ] Edit and save → form collapses back to compact row showing updated info
- [ ] Go to the feed → click any team avatar/name in a post → navigates to `/2026/blog/team/[teamId]`
- [ ] Team profile page shows correct avatar, name, robot name, bio, post count and all posts
- [ ] Profile page with no posts shows "hasn't posted anything yet" message
- [ ] Invalid teamId shows "Team not found"

https://claude.ai/code/session_016D2Y3MP3yzr2nrn2HEFhzo

---
_Generated by [Claude Code](https://claude.ai/code/session_016D2Y3MP3yzr2nrn2HEFhzo)_