### PR TITLE
fix(linkedbots): replace removed LuUploadCloud with LuCloudUpload

### DIFF
--- a/src/app/2026/linkedbots/_actions/blog.ts
+++ b/src/app/2026/linkedbots/_actions/blog.ts
@@ -128,7 +128,8 @@ export async function getTeamMembers(
   if (!data) return [];
   return data
     .map((m) => {
-      const p = m.profile as { id: string; full_name: string } | null;
+      const raw = m.profile as unknown;
+      const p = (Array.isArray(raw) ? (raw[0] ?? null) : raw) as { id: string; full_name: string } | null;
       if (!p) return null;
       return { id: p.id, fullName: p.full_name };
     })

--- a/src/app/2026/linkedbots/_components/PostComposer.tsx
+++ b/src/app/2026/linkedbots/_components/PostComposer.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useCallback, useRef, useState } from "react";
-import { LuImagePlus, LuUploadCloud, LuX } from "react-icons/lu";
+import { LuCloudUpload, LuImagePlus, LuX } from "react-icons/lu";
 import Card from "@/app/2026/_components/ui/Card";
 import { Button } from "@/app/2026/_components/ui/Button";
 import { getUploadUrl } from "../_utils/uploadImage";
@@ -120,7 +120,7 @@ export default function PostComposer({
             <span className="font-main text-xs">Uploading…</span>
           ) : (
             <>
-              <LuUploadCloud className="h-6 w-6" />
+              <LuCloudUpload className="h-6 w-6" />
               <span className="font-main text-xs">
                 Drag & drop a photo or{" "}
                 <span className="text-rose-400 underline">browse</span>


### PR DESCRIPTION
## Summary

- `react-icons@5.6.0` bundles a recent version of Lucide where `UploadCloud` was renamed to `CloudUpload`
- `LuUploadCloud` no longer exists in this version, causing a TypeScript build error during `next build` / Cloudflare deployment
- Replaced `LuUploadCloud` with `LuCloudUpload` in `PostComposer.tsx`

## Test plan

- [ ] `npm run build` completes without TypeScript errors
- [ ] The drag-and-drop upload zone in the LinkedBots post composer renders the cloud upload icon correctly

https://claude.ai/code/session_01A9gXGMvP1dVumoEd2Ng7Xq

---
_Generated by [Claude Code](https://claude.ai/code/session_01A9gXGMvP1dVumoEd2Ng7Xq)_