### PR TITLE
feat(2026): add admin-controlled PickABots homepage banner toggle

### DIFF
--- a/src/app/2026/HomeClient.tsx
+++ b/src/app/2026/HomeClient.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Fragment, useState } from "react";
+import { About } from "./_components/About/About";
+import { EventSchedule } from "./_components/EventSchedule";
+import { Sponsors } from "./_components/Sponsors";
+import Navbar from "./_components/Nav/Navbar";
+import { Banner } from "./_components/Banner";
+import PickabotsBanner from "./_components/PickabotsBanner";
+import Stats from "./_components/Stats/Stats";
+import Faq from "./_components/Faq";
+import FurtherSupport from "./_components/FurtherSupport";
+import Footer from "./_components/Footer";
+
+export default function HomeClient({
+  pickabotsEnabled,
+}: {
+  pickabotsEnabled: boolean;
+}) {
+  const [isTitleVisible, setTitleVisible] = useState(true);
+  const [isFooterVisible, setFooterVisible] = useState(false);
+  return (
+    <Fragment>
+      <Navbar
+        isTitleVisible={isTitleVisible}
+        isFooterVisible={isFooterVisible}
+      />
+      <Banner setPageTitleVisible={setTitleVisible} />
+      <div className="flex min-h-screen w-full flex-col items-center bg-black/30 pt-12">
+        <div className="max-w-5xl">
+          {pickabotsEnabled && <PickabotsBanner />}
+          <Stats />
+          <About />
+          <EventSchedule />
+          <Faq />
+          <Sponsors />
+          <FurtherSupport />
+        </div>
+      </div>
+      <Footer setFooterVisible={setFooterVisible} />
+    </Fragment>
+  );
+}

--- a/src/app/2026/_actions/appConfig.ts
+++ b/src/app/2026/_actions/appConfig.ts
@@ -9,13 +9,16 @@ export type AppConfig = {
   standard_closes: Date;
   open_closes: Date;
   payment_deadline: Date;
+  pickabots_enabled: boolean;
 };
 
 export async function getAppConfig(): Promise<AppConfig> {
   const supabase = getSupabaseSecretClient();
   const { data } = await supabase
     .from("app_config")
-    .select("standard_phase, open_phase, standard_closes, open_closes, payment_deadline")
+    .select(
+      "standard_phase, open_phase, standard_closes, open_closes, payment_deadline, pickabots_enabled",
+    )
     .eq("competition_year", 2026)
     .single();
 
@@ -26,6 +29,7 @@ export async function getAppConfig(): Promise<AppConfig> {
       standard_closes: REGISTRATION.standardCloses,
       open_closes: REGISTRATION.openCloses,
       payment_deadline: REGISTRATION.paymentDeadline,
+      pickabots_enabled: false,
     };
   }
 
@@ -35,5 +39,6 @@ export async function getAppConfig(): Promise<AppConfig> {
     standard_closes: new Date(data.standard_closes),
     open_closes: new Date(data.open_closes),
     payment_deadline: new Date(data.payment_deadline),
+    pickabots_enabled: Boolean(data.pickabots_enabled),
   };
 }

--- a/src/app/2026/_components/PickabotsBanner.tsx
+++ b/src/app/2026/_components/PickabotsBanner.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+export default function PickabotsBanner() {
+  return (
+    <Link
+      href="https://pickabots.ramsocunsw.org"
+      target="_blank"
+      className="group mx-auto mt-8 flex w-full max-w-3xl flex-col items-center gap-2 rounded-lg border border-rose-500/30 bg-rose-500/10 px-6 py-4 text-center transition-colors hover:bg-rose-500/20"
+    >
+      <span className="font-main text-xs font-semibold uppercase tracking-wider text-rose-400">
+        PickABots is live
+      </span>
+      <span className="font-main text-sm text-white md:text-base">
+        Check when your team&apos;s matches are on today, and vote for your
+        favourite bots in the fan voting competition.
+      </span>
+      <span className="font-main mt-1 flex items-center gap-1 text-sm font-semibold text-rose-400 group-hover:text-rose-300">
+        Go to PickABots
+        <svg
+          className="h-4 w-4 transition-transform group-hover:translate-x-0.5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={2}
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+        </svg>
+      </span>
+    </Link>
+  );
+}

--- a/src/app/2026/admin/_actions/config.ts
+++ b/src/app/2026/admin/_actions/config.ts
@@ -17,7 +17,9 @@ export async function getAdminAppConfig(): Promise<AppConfig> {
   const supabase = getSupabaseSecretClient();
   const { data } = await supabase
     .from("app_config")
-    .select("standard_phase, open_phase, standard_closes, open_closes, payment_deadline")
+    .select(
+      "standard_phase, open_phase, standard_closes, open_closes, payment_deadline, pickabots_enabled",
+    )
     .eq("competition_year", 2026)
     .single();
 
@@ -29,7 +31,23 @@ export async function getAdminAppConfig(): Promise<AppConfig> {
     standard_closes: new Date(data.standard_closes),
     open_closes: new Date(data.open_closes),
     payment_deadline: new Date(data.payment_deadline),
+    pickabots_enabled: Boolean(data.pickabots_enabled),
   };
+}
+
+export async function updatePickabotsToggle(
+  enabled: boolean,
+): Promise<{ success: boolean; error?: string }> {
+  await assertAdmin();
+  const supabase = getSupabaseSecretClient();
+
+  const { error } = await supabase
+    .from("app_config")
+    .update({ pickabots_enabled: enabled, updated_at: new Date().toISOString() })
+    .eq("competition_year", 2026);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true };
 }
 
 export async function updateCategoryPhase(

--- a/src/app/2026/admin/_components/SettingsPanel.tsx
+++ b/src/app/2026/admin/_components/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import Badge from "@/app/2026/_components/ui/Badge";
 import {
   updateCategoryPhase,
   updateRegistrationDates,
+  updatePickabotsToggle,
 } from "@/app/2026/admin/_actions/config";
 import type { AppConfig } from "@/app/2026/_actions/appConfig";
 
@@ -106,6 +107,23 @@ export default function SettingsPanel({ config }: { config: AppConfig }) {
     });
   }
 
+  function handleTogglePickabots(next: boolean) {
+    startTransition(async () => {
+      setError(null);
+      const result = await updatePickabotsToggle(next);
+      if (result.success) {
+        notify(
+          next
+            ? "PickABots banner is now live on the homepage."
+            : "PickABots banner hidden from the homepage.",
+        );
+        router.refresh();
+      } else {
+        setError(result.error ?? "Failed to update PickABots banner");
+      }
+    });
+  }
+
   function handleSaveDates() {
     startTransition(async () => {
       setError(null);
@@ -162,6 +180,40 @@ export default function SettingsPanel({ config }: { config: AppConfig }) {
             onToggle={(next) => handleTogglePhase("open", next)}
             isPending={isPending}
           />
+        </div>
+      </section>
+
+      {/* PickABots homepage banner */}
+      <section className="rounded-lg border border-white/10 bg-white/5 p-6">
+        <h3 className="font-main mb-1 text-base font-semibold text-white">
+          PickABots Homepage Banner
+        </h3>
+        <p className="font-main mb-4 text-sm text-gray-400">
+          Advertise PickABots on the homepage so teams can check today&apos;s
+          match schedule and fans can join the voting competition.
+        </p>
+
+        <div className="rounded-lg border border-white/10 bg-black/20 p-4">
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2 rounded-lg border border-white/10 bg-black/30 px-3 py-2">
+              <span className="font-main text-xs text-gray-400">Status:</span>
+              <Badge variant={config.pickabots_enabled ? "success" : "warning"}>
+                {config.pickabots_enabled ? "Live" : "Hidden"}
+              </Badge>
+            </div>
+            <Button
+              variant={config.pickabots_enabled ? "secondary" : "primary"}
+              size="default"
+              onClick={() => handleTogglePickabots(!config.pickabots_enabled)}
+              disabled={isPending}
+            >
+              {isPending
+                ? "Saving…"
+                : config.pickabots_enabled
+                  ? "Hide banner"
+                  : "Show banner"}
+            </Button>
+          </div>
         </div>
       </section>
 

--- a/src/app/2026/page.tsx
+++ b/src/app/2026/page.tsx
@@ -1,37 +1,9 @@
-"use client";
+import { getAppConfig } from "./_actions/appConfig";
+import HomeClient from "./HomeClient";
 
-import { Fragment, useState } from "react";
-import { About } from "./_components/About/About";
-import { EventSchedule } from "./_components/EventSchedule";
-import { Sponsors } from "./_components/Sponsors";
-import Navbar from "./_components/Nav/Navbar";
-import { Banner } from "./_components/Banner";
-import Stats from "./_components/Stats/Stats";
-import Faq from "./_components/Faq";
-import FurtherSupport from "./_components/FurtherSupport";
-import Footer from "./_components/Footer";
+export const dynamic = "force-dynamic";
 
-export default function Page() {
-  const [isTitleVisible, setTitleVisible] = useState(true);
-  const [isFooterVisible, setFooterVisible] = useState(false);
-  return (
-    <Fragment>
-      <Navbar
-        isTitleVisible={isTitleVisible}
-        isFooterVisible={isFooterVisible}
-      />
-      <Banner setPageTitleVisible={setTitleVisible} />
-      <div className="flex min-h-screen w-full flex-col items-center bg-black/30 pt-12">
-        <div className="max-w-5xl">
-          <Stats />
-          <About />
-          <EventSchedule />
-          <Faq />
-          <Sponsors />
-          <FurtherSupport />
-        </div>
-      </div>
-      <Footer setFooterVisible={setFooterVisible} />
-    </Fragment>
-  );
+export default async function Page() {
+  const config = await getAppConfig();
+  return <HomeClient pickabotsEnabled={config.pickabots_enabled} />;
 }

--- a/supabase/migrations/009_pickabots_toggle.sql
+++ b/supabase/migrations/009_pickabots_toggle.sql
@@ -1,0 +1,6 @@
+-- Admin-controlled toggle to advertise the PickABots platform on the homepage.
+-- When enabled, the homepage shows a banner linking teams/fans to PickABots
+-- for today's match schedule and the fan voting competition.
+
+ALTER TABLE app_config
+  ADD COLUMN pickabots_enabled BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
## Description

Adds an admin-controlled toggle to display a PickABots promotional banner on the 2026 homepage. This allows admins to advertise the PickABots platform (which provides match schedules and fan voting) directly on the main site.

### Changes

- **Database**: Added `pickabots_enabled` boolean column to `app_config` table (defaults to false)
- **Admin Panel**: New settings section in `SettingsPanel` to toggle the PickABots banner with live/hidden status indicator
- **Homepage**: Refactored `page.tsx` from client to server component to fetch config and conditionally render `PickabotsBanner` component
- **New Components**: 
  - `HomeClient.tsx` — Client wrapper containing homepage layout (extracted from `page.tsx`)
  - `PickabotsBanner.tsx` — Rose-themed banner linking to PickABots with call-to-action
- **Config Actions**: Added `updatePickabotsToggle()` server action and updated `getAppConfig()` to include the new field

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

## Test Plan

- Verify admin can toggle the banner on/off in the settings panel
- Confirm banner appears on homepage when enabled, hidden when disabled
- Test banner styling and link functionality on mobile and desktop
- Verify page refresh reflects config changes immediately

## Checklist

- [x] Tested locally with `npm run preview`
- [x] Reviewed mobile and desktop layouts
- [x] Code follows project conventions (server/client component split, config pattern)
- [x] PR title follows conventional commits format

https://claude.ai/code/session_01S94VKEmJVFw9ue7n1QfmXf