### PR TITLE
style(2026): make PickABots banner full-width, yellow, and more prominent

### DIFF
--- a/src/app/2026/HomeClient.tsx
+++ b/src/app/2026/HomeClient.tsx
@@ -26,9 +26,9 @@ export default function HomeClient({
         isFooterVisible={isFooterVisible}
       />
       <Banner setPageTitleVisible={setTitleVisible} />
+      {pickabotsEnabled && <PickabotsBanner />}
       <div className="flex min-h-screen w-full flex-col items-center bg-black/30 pt-12">
         <div className="max-w-5xl">
-          {pickabotsEnabled && <PickabotsBanner />}
           <Stats />
           <About />
           <EventSchedule />

--- a/src/app/2026/_components/PickabotsBanner.tsx
+++ b/src/app/2026/_components/PickabotsBanner.tsx
@@ -2,30 +2,39 @@ import Link from "next/link";
 
 export default function PickabotsBanner() {
   return (
-    <Link
-      href="https://pickabots.ramsocunsw.org"
-      target="_blank"
-      className="group mx-auto mt-8 flex w-full max-w-3xl flex-col items-center gap-2 rounded-lg border border-rose-500/30 bg-rose-500/10 px-6 py-4 text-center transition-colors hover:bg-rose-500/20"
-    >
-      <span className="font-main text-xs font-semibold uppercase tracking-wider text-rose-400">
-        PickABots is live
-      </span>
-      <span className="font-main text-sm text-white md:text-base">
-        Check when your team&apos;s matches are on today, and vote for your
-        favourite bots in the fan voting competition.
-      </span>
-      <span className="font-main mt-1 flex items-center gap-1 text-sm font-semibold text-rose-400 group-hover:text-rose-300">
-        Go to PickABots
-        <svg
-          className="h-4 w-4 transition-transform group-hover:translate-x-0.5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          strokeWidth={2}
-        >
-          <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-        </svg>
-      </span>
-    </Link>
+    <div className="w-full border-y-2 border-yellow-400 bg-yellow-400 py-6">
+      <Link
+        href="https://pickabots.ramsocunsw.org"
+        target="_blank"
+        className="group mx-auto flex w-full max-w-3xl flex-col items-center gap-2 px-6 text-center"
+      >
+        <span className="font-main text-xs font-bold uppercase tracking-widest text-black/70">
+          PickABots is live
+        </span>
+        <span className="font-main text-xl font-extrabold text-black md:text-2xl">
+          Everyone needs a PickABots account for Finals &amp; Game Day
+        </span>
+        <span className="font-main text-sm font-medium text-black/80 md:text-base">
+          Create your account now to check when your team&apos;s matches are
+          on today, and to vote in the fan voting competition. Use code{" "}
+          <span className="font-bold underline underline-offset-2">
+            SUMO26
+          </span>{" "}
+          to sign up.
+        </span>
+        <span className="font-main mt-2 flex items-center gap-2 rounded-full bg-black px-6 py-2 text-sm font-bold text-yellow-400 transition-transform group-hover:scale-105">
+          Create your account
+          <svg
+            className="h-4 w-4 transition-transform group-hover:translate-x-0.5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+          </svg>
+        </span>
+      </Link>
+    </div>
   );
 }


### PR DESCRIPTION
## Description

Follow-up to #225. Restyles the PickABots homepage banner so it's more prominent and central to the page, and calls out clearly that everyone needs a PickABots account for Finals & Game Day.

### Changes

- Moved the banner from inside the constrained content column to a full-width section directly beneath the hero, so it's the first thing visitors see below the fold
- Restyled from a subtle rose-tinted card to a bold yellow/black highlight band with a pill-shaped "Create your account" CTA
- Updated copy to emphasize that everyone needs a PickABots account for Finals & Game Day, and included the sign-up code `SUMO26`

## Type of change

- [x] New Feature (non-breaking change which adds functionality)

## Checklist

- [x] Tested locally with `npx tsc --noEmit` and `next build`
- [x] Reviewed mobile and desktop layout classes (responsive text sizing)
- [x] My PR title follows conventional commits format


---
_Generated by [Claude Code](https://claude.ai/code/session_01S94VKEmJVFw9ue7n1QfmXf)_