### PR TITLE
fix(2026): hero overlap + PickABots account popup for signed-in users

### DIFF
--- a/src/app/2026/HomeClient.tsx
+++ b/src/app/2026/HomeClient.tsx
@@ -7,6 +7,7 @@ import { Sponsors } from "./_components/Sponsors";
 import Navbar from "./_components/Nav/Navbar";
 import { Banner } from "./_components/Banner";
 import PickabotsBanner from "./_components/PickabotsBanner";
+import PickabotsAccountModal from "./_components/PickabotsAccountModal";
 import Stats from "./_components/Stats/Stats";
 import Faq from "./_components/Faq";
 import FurtherSupport from "./_components/FurtherSupport";
@@ -14,13 +15,16 @@ import Footer from "./_components/Footer";
 
 export default function HomeClient({
   pickabotsEnabled,
+  showPickabotsPrompt,
 }: {
   pickabotsEnabled: boolean;
+  showPickabotsPrompt: boolean;
 }) {
   const [isTitleVisible, setTitleVisible] = useState(true);
   const [isFooterVisible, setFooterVisible] = useState(false);
   return (
     <Fragment>
+      <PickabotsAccountModal show={showPickabotsPrompt} />
       <Navbar
         isTitleVisible={isTitleVisible}
         isFooterVisible={isFooterVisible}

--- a/src/app/2026/_actions/pickabots.ts
+++ b/src/app/2026/_actions/pickabots.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { getSupabaseSecretClient } from "@/app/_utils/supabase";
+import { getProfile } from "@/app/2026/_actions/profile";
+
+export type PickabotsStatus = {
+  onboarded: boolean;
+  isSpectator: boolean;
+};
+
+export async function getPickabotsStatus(): Promise<PickabotsStatus | null> {
+  const profile = await getProfile();
+  if (!profile) return null;
+
+  const supabase = getSupabaseSecretClient();
+  const { data, error } = await supabase
+    .from("users") // pickabots' table, same Supabase project
+    .select("onboarded, is_spectator, profile_id")
+    .eq("profile_id", profile.id)
+    .limit(1);
+
+  if (error) {
+    throw new Error(`Failed to check pickabots onboarding: ${error.message}`);
+  }
+
+  const row = data?.[0];
+  return {
+    onboarded: Boolean(row?.onboarded),
+    isSpectator: Boolean(row?.is_spectator),
+  };
+}

--- a/src/app/2026/_components/Banner.tsx
+++ b/src/app/2026/_components/Banner.tsx
@@ -68,9 +68,9 @@ export const Banner = ({
   return (
     <div
       id="banner"
-      className="relative flex h-[100vh] min-h-[50rem] flex-col items-center justify-center"
+      className="relative flex min-h-[100vh] flex-col items-center justify-center py-24"
     >
-      <div className="absolute top-1/2 left-[50vw] -translate-x-1/2 -translate-y-1/4">
+      <div>
         <h1 ref={titleRef} className="leading-none">
           <span className="self-start text-[0.8rem] md:text-[1rem] xl:text-[1.5rem]">
             <span className="text-rose-600">2026</span> RAMSOC UNSW PRESENTS

--- a/src/app/2026/_components/PickabotsAccountModal.tsx
+++ b/src/app/2026/_components/PickabotsAccountModal.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+
+export default function PickabotsAccountModal({ show }: { show: boolean }) {
+  const [dismissed, setDismissed] = useState(false);
+  if (!show || dismissed) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4">
+      <div className="relative w-full max-w-md rounded-2xl border border-yellow-400/40 bg-zinc-900 p-6 text-center shadow-2xl">
+        <button
+          onClick={() => setDismissed(true)}
+          aria-label="Close"
+          className="absolute top-4 right-4 text-gray-500 transition-colors hover:text-white"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            strokeWidth={2}
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+
+        <span className="font-main text-xs font-bold tracking-widest text-yellow-400 uppercase">
+          One more thing
+        </span>
+        <h2 className="font-main mt-2 text-xl font-extrabold text-white">
+          Set up your PickABots account
+        </h2>
+        <p className="font-main mt-3 text-sm text-gray-300">
+          You&apos;ll need a PickABots account to check when your matches are
+          on during Finals &amp; Game Day, and to vote in the fan voting
+          competition. Use code{" "}
+          <span className="font-bold text-yellow-400 underline underline-offset-2">
+            SUMO26
+          </span>{" "}
+          to sign up.
+        </p>
+
+        <div className="mt-6 flex flex-col gap-2">
+          <Link
+            href="https://pickabots.ramsocunsw.org"
+            target="_blank"
+            onClick={() => setDismissed(true)}
+            className="font-main rounded-full bg-yellow-400 px-6 py-3 text-sm font-bold text-black transition-transform hover:scale-105"
+          >
+            Create your account
+          </Link>
+          <button
+            onClick={() => setDismissed(true)}
+            className="font-main text-xs text-gray-500 transition-colors hover:text-gray-300"
+          >
+            Not now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/2026/_components/PickabotsBanner.tsx
+++ b/src/app/2026/_components/PickabotsBanner.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 export default function PickabotsBanner() {
   return (
-    <div className="w-full border-y-2 border-yellow-400 bg-yellow-400 py-6">
+    <div className="w-full border-y-2 border-yellow-400/90 bg-yellow-400/90 py-6">
       <Link
         href="https://pickabots.ramsocunsw.org"
         target="_blank"

--- a/src/app/2026/page.tsx
+++ b/src/app/2026/page.tsx
@@ -1,9 +1,24 @@
 import { getAppConfig } from "./_actions/appConfig";
+import { getPickabotsStatus } from "./_actions/pickabots";
 import HomeClient from "./HomeClient";
 
 export const dynamic = "force-dynamic";
 
 export default async function Page() {
-  const config = await getAppConfig();
-  return <HomeClient pickabotsEnabled={config.pickabots_enabled} />;
+  const [config, pickabotsStatus] = await Promise.all([
+    getAppConfig(),
+    getPickabotsStatus(),
+  ]);
+
+  const showPickabotsPrompt =
+    pickabotsStatus !== null &&
+    !pickabotsStatus.onboarded &&
+    !pickabotsStatus.isSpectator;
+
+  return (
+    <HomeClient
+      pickabotsEnabled={config.pickabots_enabled}
+      showPickabotsPrompt={showPickabotsPrompt}
+    />
+  );
 }


### PR DESCRIPTION
## Description

Follow-up to #225/#226. Fixes a layout bug exposed by the new PickABots banner, and adds a popup nudging signed-in users to set up a PickABots account.

### Changes

- **Layout fix**: `Banner.tsx`'s hero used a fixed `h-[100vh]` with its content absolutely positioned inside. When content grew taller (e.g. the "Registration Closed" state, which adds an extra line), it silently overflowed the box and overlapped the PickABots banner below. Switched to `min-h-screen` with in-flow content so the section grows to fit instead of clipping.
- Softened the PickABots banner to a slightly translucent yellow (`bg-yellow-400/90`).
- **New popup**: `PickabotsAccountModal` shows on the homepage for signed-in users who haven't set up a PickABots account yet, prompting them to create one for Finals & Game Day and the fan voting competition (with sign-up code `SUMO26`). Detection is real, not self-reported — PickABots and Sumobots share one Supabase project, so `getPickabotsStatus()` looks up the PickABots `users` row by the signed-in user's `profiles.id` and only shows the prompt when there's no row (or they're a spectator who's already onboarded).

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New Feature (non-breaking change which adds functionality)

## Checklist

- [x] Tested locally with `npx tsc --noEmit` and `next build`
- [x] Reviewed mobile and desktop layout classes
- [x] My PR title follows conventional commits format


---
_Generated by [Claude Code](https://claude.ai/code/session_01S94VKEmJVFw9ue7n1QfmXf)_